### PR TITLE
Add instruction to commit parent after child commits

### DIFF
--- a/CLAUDE.md.snippet
+++ b/CLAUDE.md.snippet
@@ -7,6 +7,7 @@
 1. **Base folders stay on main** - Check `./sailkit-dev/scripts/worktree-list` to see which folders are bases
 2. **Create worktrees for tasks** - Each task gets its own worktree
 3. **Never switch branches in base folders** - Use `worktree-new`, not `git checkout`
+4. **Commit parent after child commits** - After committing in a worktree, commit and push the parent project to update `workflow.jsonl`
 
 ## Commands
 


### PR DESCRIPTION
## Summary
- Adds rule 4 to CLAUDE.md.snippet: always commit and push the parent project after committing in a worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)