### PR TITLE
Fix README naming: replace Sailkit references with Bearing

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,26 +4,26 @@ Worktree-based workflow for parallel AI-assisted development.
 
 ## Why
 
-When multiple AI agents work on the same codebase, they can step on each other if they switch branches in shared folders. Sailkit enforces a worktree-per-task pattern that keeps agents isolated.
+When multiple AI agents work on the same codebase, they can step on each other if they switch branches in shared folders. Bearing enforces a worktree-per-task pattern that keeps agents isolated.
 
 ## Install
 
 ```bash
-git clone https://github.com/sailkit-dev/sailkit-dev ~/Projects/sailkit-dev
-~/Projects/sailkit-dev/install.sh
+git clone https://github.com/bearing-dev/bearing ~/Projects/bearing
+~/Projects/bearing/install.sh
 ```
 
-The installer prompts for scope (project-level or global) and creates symlinks to Sailkit's skills.
+The installer prompts for scope (project-level or global) and creates symlinks to Bearing's skills.
 
 ## Architecture
 
-Sailkit leverages git's existing capabilities rather than duplicating them:
+Bearing leverages git's existing capabilities rather than duplicating them:
 
 | Layer | Responsibility | Storage |
 |-------|---------------|---------|
 | **Git submodules** | Commit pointers, remotes, branch refs | `.gitmodules`, `.git/` |
 | **Manifest** | Workflow metadata cache (purposes, status) | `workflow.jsonl`, `local.jsonl` |
-| **Scripts** | Orchestration, guardrails | `sailkit-dev/scripts/` |
+| **Scripts** | Orchestration, guardrails | `bearing/scripts/` |
 
 **Design principle:** Git is the source of truth. The manifest is a cache of computed state plus workflow metadata. After a fresh clone, run `worktree-sync` to rebuild the manifest from git state.
 
@@ -31,7 +31,7 @@ Sailkit leverages git's existing capabilities rather than duplicating them:
 ```bash
 git clone --recurse-submodules https://github.com/user/projects.git
 cd projects
-./sailkit-dev/scripts/worktree-sync  # Rebuild manifest from git
+./bearing/scripts/worktree-sync  # Rebuild manifest from git
 ```
 
 ## Concepts
@@ -40,7 +40,7 @@ cd projects
 - **Worktrees** (e.g., `fightingwithai.com-feature/`) are created for tasks
 - **Workflow state** (`workflow.jsonl`) tracks branches, purposes, relationships (committable)
 - **Local state** (`local.jsonl`) tracks worktree folders (not committed)
-- **Config** (`.sailkit.yaml`) defines workspace repos and settings
+- **Config** (`.bearing.yaml`) defines workspace repos and settings
 
 ## Commands
 
@@ -48,23 +48,23 @@ Run from your Projects folder:
 
 | Command | Description |
 |---------|-------------|
-| `./sailkit-dev/scripts/worktree-new <repo> <branch>` | Create worktree for branch |
-| `./sailkit-dev/scripts/worktree-cleanup <repo> <branch>` | Remove worktree after merge |
-| `./sailkit-dev/scripts/worktree-sync` | Rebuild manifest from git state |
-| `./sailkit-dev/scripts/worktree-list` | Display manifest as ASCII table |
-| `./sailkit-dev/scripts/worktree-register <folder>` | Register existing folder as base |
-| `./sailkit-dev/scripts/worktree-check` | Validate invariants (base folders on main) |
+| `./bearing/scripts/worktree-new <repo> <branch>` | Create worktree for branch |
+| `./bearing/scripts/worktree-cleanup <repo> <branch>` | Remove worktree after merge |
+| `./bearing/scripts/worktree-sync` | Rebuild manifest from git state |
+| `./bearing/scripts/worktree-list` | Display manifest as ASCII table |
+| `./bearing/scripts/worktree-register <folder>` | Register existing folder as base |
+| `./bearing/scripts/worktree-check` | Validate invariants (base folders on main) |
 
 ### Options
 
 ```bash
 # Create worktree with metadata
-./sailkit-dev/scripts/worktree-new myrepo feature-x --based-on develop --purpose "Add login"
+./bearing/scripts/worktree-new myrepo feature-x --based-on develop --purpose "Add login"
 ```
 
 ## State Files
 
-Sailkit uses two state files in the workspace root:
+Bearing uses two state files in the workspace root:
 
 **workflow.jsonl** (committable - portable across machines):
 ```jsonl
@@ -81,7 +81,7 @@ Agents should interact via scripts, never edit these files directly.
 
 ## Config
 
-`.sailkit.yaml` defines the workspace:
+`.bearing.yaml` defines the workspace:
 ```yaml
 repos:
   - name: myrepo
@@ -111,7 +111,7 @@ The Python harness provides:
 
 ## Hooks
 
-Sailkit integrates with Claude Code's hook system to check invariants before each action.
+Bearing integrates with Claude Code's hook system to check invariants before each action.
 
 Add to `.claude/settings.json`:
 
@@ -123,7 +123,7 @@ Add to `.claude/settings.json`:
         "hooks": [
           {
             "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR\"/sailkit-dev/scripts/worktree-check --json"
+            "command": "\"$CLAUDE_PROJECT_DIR\"/bearing/scripts/worktree-check --json"
           }
         ]
       }
@@ -158,8 +158,8 @@ Documented for future consideration:
 A wrapper script that runs pre-flight checks before launching any AI agent:
 ```bash
 #!/bin/bash
-./sailkit-dev/scripts/worktree-check || { echo "Fix violations first"; exit 1; }
-exec "${SAILKIT_AGENT:-claude}" "$@"
+./bearing/scripts/worktree-check || { echo "Fix violations first"; exit 1; }
+exec "${BEARING_AGENT:-claude}" "$@"
 ```
 Benefits: True blocking (refuses to start), portable across agents (Claude, Cursor, Aider), clear error display. Current hook approach works within Claude Code's system but cannot truly block session start.
 
@@ -167,7 +167,7 @@ Benefits: True blocking (refuses to start), portable across agents (Claude, Curs
 - **worktree-push**: Push branch and optionally create PR
 - **worktree-finish**: Push + PR + mark complete in workflow.jsonl
 - **worktree-checkout**: Recreate local worktree from workflow.jsonl entry (for switching machines)
-- **Auto-PR templates**: Configure PR body template in .sailkit.yaml
+- **Auto-PR templates**: Configure PR body template in .bearing.yaml
 
 ### Validation & Safety
 - **Auto-fix with --force**: `worktree-check --fix` to checkout main on violating base folders
@@ -175,8 +175,8 @@ Benefits: True blocking (refuses to start), portable across agents (Claude, Curs
 - **Cross-repo coordination**: Track which agent owns which worktree
 
 ### Configuration
-- **Local overrides**: `~/.sailkit.yaml` for user-specific settings
-- **Per-repo config**: `.sailkit.yaml` in each repo for repo-specific behavior
+- **Local overrides**: `~/.bearing.yaml` for user-specific settings
+- **Per-repo config**: `.bearing.yaml` in each repo for repo-specific behavior
 - **Workflow config**: autoPush, autoPR, cleanupOnMerge settings
 
 ### Platform Support


### PR DESCRIPTION
## Summary
- Replace all "Sailkit" text references with "Bearing"
- Update clone URL from sailkit-dev to bearing-dev
- Update script paths from sailkit-dev/scripts/ to bearing/scripts/
- Update config file references from .sailkit.yaml to .bearing.yaml
- Update SAILKIT_AGENT env var to BEARING_AGENT

## Test plan
- [x] Verify all Sailkit references are replaced
- [ ] Review diff for correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)