### PR TITLE
Add session persistence - remember selection across restarts

### DIFF
--- a/tui/bearing_tui/app.py
+++ b/tui/bearing_tui/app.py
@@ -174,7 +174,7 @@ class BearingApp(App):
             if hasattr(item, "project") and item.project == project:
                 project_list.index = i
                 self._current_project = project
-                self._update_worktrees(project)
+                self._update_worktree_table(project)
                 break
 
     def on_mount(self) -> None:


### PR DESCRIPTION
## Summary
- Save selected project on quit to ~/.bearing/tui-session.json
- Restore selection on startup if < 24 hours old

## Test plan
- [ ] Open TUI, select a project, quit
- [ ] Reopen TUI - same project should be selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)