### PR TITLE
Add auto-create issues for plan sync

### DIFF
--- a/internal/cli/plan_push.go
+++ b/internal/cli/plan_push.go
@@ -32,6 +32,7 @@ type planFrontmatter struct {
 	Issue  string
 	Repo   string
 	Status string
+	Title  string
 }
 
 func runPlanPush(cmd *cobra.Command, args []string) error {
@@ -43,16 +44,67 @@ func runPlanPush(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if fm.Issue == "" {
-		return fmt.Errorf("no issue number in frontmatter")
-	}
+	// Auto-infer repo from path: plans/<project>/xxx.md
 	if fm.Repo == "" {
-		return fmt.Errorf("no repo in frontmatter")
+		fm.Repo = inferRepoFromPath(planFile)
+		if fm.Repo == "" {
+			return fmt.Errorf("no repo in frontmatter and couldn't infer from path")
+		}
+		fmt.Printf("Auto-detected repo: %s\n", fm.Repo)
+	}
+
+	// Auto-infer title from first markdown heading if not in frontmatter
+	if fm.Title == "" {
+		fm.Title = extractTitleFromBody(body)
+		if fm.Title == "" {
+			return fmt.Errorf("no title in frontmatter and no markdown heading found")
+		}
+		fmt.Printf("Auto-detected title: %s\n", fm.Title)
 	}
 
 	// Trim leading/trailing whitespace from body
 	body = strings.TrimSpace(body)
 
+	repoPath := filepath.Join(WorkspaceDir(), fm.Repo)
+
+	if fm.Issue == "" {
+		// Create new issue
+		if planPushDryRun {
+			fmt.Printf("Would create issue in %s:\n", fm.Repo)
+			fmt.Printf("Title: %s\n", fm.Title)
+			fmt.Printf("Body:\n%s\n", body)
+			return nil
+		}
+
+		ghCmd := exec.Command("gh", "issue", "create",
+			"--title", fm.Title,
+			"--body", body,
+			"--label", "plan")
+		ghCmd.Dir = repoPath
+		var stdout, stderr bytes.Buffer
+		ghCmd.Stdout = &stdout
+		ghCmd.Stderr = &stderr
+
+		if err := ghCmd.Run(); err != nil {
+			return fmt.Errorf("failed to create issue: %w\n%s", err, stderr.String())
+		}
+
+		// Parse issue number from output (URL format: https://github.com/owner/repo/issues/123)
+		url := strings.TrimSpace(stdout.String())
+		parts := strings.Split(url, "/")
+		issueNum := parts[len(parts)-1]
+
+		// Update frontmatter with issue number
+		if err := updateFrontmatter(planFile, "issue", issueNum); err != nil {
+			fmt.Printf("Warning: created issue #%s but failed to update frontmatter: %v\n", issueNum, err)
+		}
+
+		fmt.Printf("Created issue #%s in %s\n", issueNum, fm.Repo)
+		fmt.Printf("URL: %s\n", url)
+		return nil
+	}
+
+	// Update existing issue
 	if planPushDryRun {
 		fmt.Printf("Would update issue %s in %s:\n", fm.Issue, fm.Repo)
 		fmt.Printf("Status: %s\n", fm.Status)
@@ -60,8 +112,6 @@ func runPlanPush(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	// Push to GitHub using gh issue edit
-	repoPath := filepath.Join(WorkspaceDir(), fm.Repo)
 	ghCmd := exec.Command("gh", "issue", "edit", fm.Issue, "--body", body)
 	ghCmd.Dir = repoPath
 	var stderr bytes.Buffer
@@ -73,6 +123,75 @@ func runPlanPush(cmd *cobra.Command, args []string) error {
 
 	fmt.Printf("Updated issue %s in %s\n", fm.Issue, fm.Repo)
 	return nil
+}
+
+// inferRepoFromPath extracts repo name from plan path: plans/<project>/xxx.md
+func inferRepoFromPath(planFile string) string {
+	// Get absolute path
+	absPath, err := filepath.Abs(planFile)
+	if err != nil {
+		return ""
+	}
+
+	// Look for "plans" directory in path
+	parts := strings.Split(absPath, string(filepath.Separator))
+	for i, part := range parts {
+		if part == "plans" && i+1 < len(parts) {
+			return parts[i+1]
+		}
+	}
+	return ""
+}
+
+// extractTitleFromBody extracts the first markdown heading from the body
+func extractTitleFromBody(body string) string {
+	scanner := bufio.NewScanner(strings.NewReader(body))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "# ") {
+			return strings.TrimPrefix(line, "# ")
+		}
+	}
+	return ""
+}
+
+// updateFrontmatter updates or adds a field in the frontmatter
+func updateFrontmatter(planFile, key, value string) error {
+	content, err := os.ReadFile(planFile)
+	if err != nil {
+		return err
+	}
+
+	lines := strings.Split(string(content), "\n")
+	var result []string
+	inFrontmatter := false
+	updated := false
+
+	for i, line := range lines {
+		if line == "---" {
+			if !inFrontmatter && i == 0 {
+				inFrontmatter = true
+				result = append(result, line)
+				continue
+			} else if inFrontmatter {
+				// End of frontmatter - add field if not updated
+				if !updated {
+					result = append(result, fmt.Sprintf("%s: %s", key, value))
+				}
+				inFrontmatter = false
+			}
+		}
+
+		if inFrontmatter && strings.HasPrefix(line, key+":") {
+			result = append(result, fmt.Sprintf("%s: %s", key, value))
+			updated = true
+			continue
+		}
+
+		result = append(result, line)
+	}
+
+	return os.WriteFile(planFile, []byte(strings.Join(result, "\n")), 0644)
 }
 
 // stripQuotes removes leading/trailing single or double quotes from a string.
@@ -113,6 +232,7 @@ func parsePlanFile(path string) (*planFrontmatter, string, error) {
 	var body strings.Builder
 	inFrontmatter := false
 	frontmatterDone := false
+	lineNum := 0
 
 	scanner := bufio.NewScanner(f)
 	// Bug 1 fix: Increase buffer size to handle long lines (up to 1MB)
@@ -121,9 +241,11 @@ func parsePlanFile(path string) (*planFrontmatter, string, error) {
 
 	for scanner.Scan() {
 		line := scanner.Text()
+		lineNum++
 
 		if line == "---" {
-			if !inFrontmatter && !frontmatterDone {
+			if !inFrontmatter && !frontmatterDone && lineNum == 1 {
+				// Only start frontmatter if --- is on line 1
 				inFrontmatter = true
 				continue
 			} else if inFrontmatter {
@@ -146,18 +268,23 @@ func parsePlanFile(path string) (*planFrontmatter, string, error) {
 				}
 				switch key {
 				case "issue":
-					// Bug 3 fix: Validate issue number is numeric
-					if !isNumeric(val) {
-						return nil, "", fmt.Errorf("issue must be numeric, got: %q", val)
+					// Bug 3 fix: Validate issue number is numeric (skip "null")
+					if val != "null" && val != "" {
+						if !isNumeric(val) {
+							return nil, "", fmt.Errorf("issue must be numeric, got: %q", val)
+						}
+						fm.Issue = val
 					}
-					fm.Issue = val
 				case "repo":
 					fm.Repo = val
 				case "status":
 					fm.Status = val
+				case "title":
+					fm.Title = val
 				}
 			}
-		} else if frontmatterDone {
+		} else {
+			// No frontmatter or after frontmatter - treat as body
 			body.WriteString(line)
 			body.WriteString("\n")
 		}

--- a/internal/cli/plan_sync.go
+++ b/internal/cli/plan_sync.go
@@ -57,28 +57,78 @@ func runPlanSync(cmd *cobra.Command, args []string) error {
 
 	fmt.Printf("Found %d plan files\n", len(planFiles))
 
+	created := 0
+	updated := 0
+	errors := 0
+
 	for _, pf := range planFiles {
-		fm, _, err := parsePlanFile(pf)
+		fm, body, err := parsePlanFile(pf)
 		if err != nil {
-			fmt.Printf("  %s: error parsing (%v)\n", pf, err)
+			fmt.Printf("  %s: error parsing (%v)\n", filepath.Base(pf), err)
+			errors++
 			continue
 		}
 
-		if fm.Issue == "" {
-			fmt.Printf("  %s: no issue linked\n", pf)
-			continue
-		}
-
-		if planSyncDryRun {
-			fmt.Printf("  %s: would sync to %s#%s\n", pf, fm.Repo, fm.Issue)
-		} else {
-			fmt.Printf("  %s: syncing to %s#%s... ", pf, fm.Repo, fm.Issue)
-			if err := pushPlanToIssue(pf, fm); err != nil {
-				fmt.Printf("ERROR: %v\n", err)
-			} else {
-				fmt.Printf("OK\n")
+		// Auto-infer repo from path if missing
+		if fm.Repo == "" {
+			fm.Repo = inferRepoFromPath(pf)
+			if fm.Repo == "" {
+				fmt.Printf("  %s: no repo configured\n", filepath.Base(pf))
+				errors++
+				continue
 			}
 		}
+
+		// Auto-infer title from markdown heading if missing
+		if fm.Title == "" {
+			fm.Title = extractTitleFromBody(body)
+			if fm.Title == "" {
+				fmt.Printf("  %s: no title or heading\n", filepath.Base(pf))
+				errors++
+				continue
+			}
+		}
+
+		repoPath := filepath.Join(WorkspaceDir(), fm.Repo)
+		body = strings.TrimSpace(body)
+
+		if fm.Issue == "" {
+			// Create new issue
+			if planSyncDryRun {
+				fmt.Printf("  %s: would create issue in %s\n", filepath.Base(pf), fm.Repo)
+				created++
+			} else {
+				fmt.Printf("  %s: creating issue in %s... ", filepath.Base(pf), fm.Repo)
+				issueNum, err := createIssueForPlan(repoPath, pf, fm.Title, body)
+				if err != nil {
+					fmt.Printf("ERROR: %v\n", err)
+					errors++
+				} else {
+					fmt.Printf("OK (#%s)\n", issueNum)
+					created++
+				}
+			}
+		} else {
+			// Update existing issue
+			if planSyncDryRun {
+				fmt.Printf("  %s: would sync to %s#%s\n", filepath.Base(pf), fm.Repo, fm.Issue)
+				updated++
+			} else {
+				fmt.Printf("  %s: syncing to %s#%s... ", filepath.Base(pf), fm.Repo, fm.Issue)
+				if err := pushPlanToIssue(pf, fm); err != nil {
+					fmt.Printf("ERROR: %v\n", err)
+					errors++
+				} else {
+					fmt.Printf("OK\n")
+					updated++
+				}
+			}
+		}
+	}
+
+	fmt.Printf("\nSummary: %d created, %d updated, %d errors\n", created, updated, errors)
+	if planSyncDryRun {
+		fmt.Println("(dry run - no changes made)")
 	}
 
 	return nil
@@ -105,4 +155,31 @@ func pushPlanToIssue(planFile string, fm *planFrontmatter) error {
 	}
 
 	return nil
+}
+
+func createIssueForPlan(repoPath, planFile, title, body string) (string, error) {
+	ghCmd := exec.Command("gh", "issue", "create",
+		"--title", title,
+		"--body", body,
+		"--label", "plan")
+	ghCmd.Dir = repoPath
+	var stdout, stderr bytes.Buffer
+	ghCmd.Stdout = &stdout
+	ghCmd.Stderr = &stderr
+
+	if err := ghCmd.Run(); err != nil {
+		return "", fmt.Errorf("%w: %s", err, stderr.String())
+	}
+
+	// Parse issue number from output URL: https://github.com/owner/repo/issues/123
+	url := strings.TrimSpace(stdout.String())
+	parts := strings.Split(url, "/")
+	issueNum := parts[len(parts)-1]
+
+	// Update frontmatter with issue number
+	if err := updateFrontmatter(planFile, "issue", issueNum); err != nil {
+		return issueNum, fmt.Errorf("created issue but failed to update frontmatter: %w", err)
+	}
+
+	return issueNum, nil
 }


### PR DESCRIPTION
## Summary
- Auto-infer title from markdown heading if not in frontmatter
- Auto-infer repo from path (`plans/<project>/xxx.md`)
- Create GitHub issues automatically for plans without issue numbers
- Update frontmatter with issue number after creation
- Handle files both with and without YAML frontmatter

## Test plan
- [x] `bearing plan sync --project bearing --dry-run` shows correct create/update counts
- [x] `bearing plan sync --project bearing` creates issues with `plan` label
- [x] Frontmatter updated with issue numbers after creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)