### PR TITLE
Add plans browser modal to TUI

### DIFF
--- a/tui/bearing_tui/app.py
+++ b/tui/bearing_tui/app.py
@@ -19,6 +19,8 @@ from bearing_tui.widgets import (
     DetailsPanel,
     LocalEntry,
     WorkflowEntry,
+    PlansList,
+    load_plans,
 )
 
 
@@ -52,12 +54,60 @@ class HelpScreen(ModalScreen):
                 "  [yellow]R[/]      Force refresh (daemon)\n"
                 "  [yellow]d[/]      Daemon health check\n"
                 "  [yellow]o[/]      Open PR in browser\n"
+                "  [yellow]p[/]      View plans\n"
                 "  [yellow]?[/]      Show this help\n"
                 "  [yellow]q[/]      Quit\n",
                 id="help-content",
             ),
             id="help-modal",
         )
+
+
+class PlansScreen(ModalScreen):
+    """Modal screen showing plans list."""
+
+    BINDINGS = [
+        Binding("escape", "dismiss", "Close"),
+        Binding("q", "dismiss", "Close"),
+        Binding("p", "dismiss", "Close"),
+        Binding("j", "cursor_down", "Down", show=False),
+        Binding("k", "cursor_up", "Up", show=False),
+        Binding("o", "open_issue", "Open Issue", show=False),
+    ]
+
+    def __init__(self, workspace: Path) -> None:
+        super().__init__()
+        self.workspace = workspace
+
+    def compose(self) -> ComposeResult:
+        yield Container(
+            Static("[b cyan]Plans[/] [dim](press o to open issue, Esc to close)[/]", id="plans-header"),
+            PlansList(id="plans-list"),
+            id="plans-modal",
+        )
+
+    def on_mount(self) -> None:
+        plans = load_plans(self.workspace)
+        plans_list = self.query_one("#plans-list", PlansList)
+        plans_list.set_plans(plans)
+        plans_list.focus()
+
+    def action_cursor_down(self) -> None:
+        self.query_one(PlansList).action_cursor_down()
+
+    def action_cursor_up(self) -> None:
+        self.query_one(PlansList).action_cursor_up()
+
+    def action_open_issue(self) -> None:
+        """Open the selected plan's issue in browser."""
+        plans_list = self.query_one(PlansList)
+        if plans_list.index is not None and plans_list.index < len(plans_list._plans):
+            plan = plans_list._plans[plans_list.index]
+            if plan.issue:
+                # Get repo from the plan's project name
+                url = f"https://github.com/joshribakoff/{plan.project}/issues/{plan.issue}"
+                webbrowser.open(url)
+                self.app.notify(f"Opened issue #{plan.issue}", timeout=2)
 
 
 class BearingApp(App):
@@ -76,6 +126,7 @@ class BearingApp(App):
         Binding("R", "force_refresh", "Force Refresh", show=False),
         Binding("d", "daemon", "Daemon"),
         Binding("o", "open_pr", "Open PR", show=False),
+        Binding("p", "show_plans", "Plans"),
         # Panel navigation by number (0-indexed)
         Binding("0", "focus_panel_0", "Projects", show=False),
         Binding("1", "focus_panel_1", "Worktrees", show=False),
@@ -126,6 +177,7 @@ class BearingApp(App):
             "[yellow]c[/]leanup  "
             "[yellow]r[/]efresh  "
             "[yellow]o[/]pen PR  "
+            "[yellow]p[/]lans  "
             "[yellow]?[/] help  "
             "[yellow]q[/]uit",
             id="footer-bar"
@@ -140,6 +192,10 @@ class BearingApp(App):
     def action_show_help(self) -> None:
         """Show the help modal."""
         self.push_screen(HelpScreen())
+
+    def action_show_plans(self) -> None:
+        """Show the plans modal."""
+        self.push_screen(PlansScreen(self.workspace))
 
     def action_refresh(self) -> None:
         """Refresh data from files."""

--- a/tui/bearing_tui/styles/app.tcss
+++ b/tui/bearing_tui/styles/app.tcss
@@ -238,3 +238,51 @@ Toast {
     color: $text;
     border: round $accent-blue;
 }
+
+/* Plans modal styling */
+PlansScreen {
+    align: center middle;
+}
+
+#plans-modal {
+    width: 80;
+    height: auto;
+    max-height: 80%;
+    background: $bg-panel;
+    border: round $accent-purple;
+    padding: 1 2;
+}
+
+#plans-header {
+    height: 1;
+    margin-bottom: 1;
+}
+
+PlansList {
+    background: $bg-panel;
+    height: auto;
+    max-height: 20;
+    border: none;
+}
+
+PlanListItem {
+    padding: 0 1;
+    height: 1;
+    background: transparent;
+    color: $text;
+}
+
+PlanListItem:hover {
+    background: $bg-highlight;
+}
+
+PlanListItem.-highlight {
+    background: $bg-selection;
+    color: $text-bright;
+}
+
+PlansList:focus PlanListItem.-highlight {
+    background: #2d5a8a;
+    color: $text-bright;
+    text-style: bold;
+}

--- a/tui/bearing_tui/widgets/__init__.py
+++ b/tui/bearing_tui/widgets/__init__.py
@@ -3,6 +3,7 @@ from .projects import ProjectList
 from .worktrees import WorktreeTable, WorktreeEntry, HealthEntry
 from .details import DetailsPanel, LocalEntry, WorkflowEntry
 from .details import HealthEntry as DetailsHealthEntry
+from .plans import PlansList, PlanEntry, load_plans
 
 __all__ = [
     "ProjectList",
@@ -12,4 +13,7 @@ __all__ = [
     "DetailsPanel",
     "LocalEntry",
     "WorkflowEntry",
+    "PlansList",
+    "PlanEntry",
+    "load_plans",
 ]

--- a/tui/bearing_tui/widgets/plans.py
+++ b/tui/bearing_tui/widgets/plans.py
@@ -1,0 +1,141 @@
+"""Plans list widget for displaying plans from ~/Projects/plans/."""
+
+from pathlib import Path
+from typing import NamedTuple
+
+from textual.widgets import ListView, ListItem, Static
+from textual.message import Message
+
+
+class PlanEntry(NamedTuple):
+    """Represents a plan entry."""
+    file_path: Path
+    project: str
+    title: str
+    issue: str | None
+    status: str
+
+
+class PlanListItem(ListItem):
+    """A list item representing a plan."""
+
+    def __init__(self, plan: PlanEntry) -> None:
+        super().__init__()
+        self.plan = plan
+
+    def compose(self):
+        status_indicator = {
+            "active": "[green]●[/]",
+            "in_progress": "[yellow]●[/]",
+            "draft": "[dim]●[/]",
+            "completed": "[blue]●[/]",
+        }.get(self.plan.status, "[dim]○[/]")
+
+        issue_str = f"[cyan]#{self.plan.issue}[/]" if self.plan.issue else "[dim]no issue[/]"
+
+        yield Static(
+            f"{status_indicator} {self.plan.title[:40]:<40} "
+            f"[dim]{self.plan.project}[/] {issue_str}"
+        )
+
+
+class PlansList(ListView):
+    """ListView showing plans from the plans directory."""
+
+    class PlanSelected(Message):
+        """Posted when a plan is selected."""
+        def __init__(self, plan: PlanEntry) -> None:
+            self.plan = plan
+            super().__init__()
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._plans: list[PlanEntry] = []
+
+    def set_plans(self, plans: list[PlanEntry]) -> None:
+        """Set the plans to display."""
+        self._plans = plans
+        self.clear()
+        for plan in plans:
+            self.append(PlanListItem(plan))
+
+    def on_list_view_selected(self, event: ListView.Selected) -> None:
+        """Handle plan selection."""
+        item = event.item
+        if isinstance(item, PlanListItem):
+            self.post_message(self.PlanSelected(item.plan))
+
+
+def parse_plan_frontmatter(file_path: Path) -> dict:
+    """Parse YAML frontmatter from a plan file."""
+    content = file_path.read_text()
+    lines = content.split("\n")
+
+    frontmatter = {}
+    in_frontmatter = False
+
+    for i, line in enumerate(lines):
+        if line.strip() == "---":
+            if not in_frontmatter and i == 0:
+                in_frontmatter = True
+                continue
+            elif in_frontmatter:
+                break
+        elif in_frontmatter:
+            if ":" in line:
+                key, value = line.split(":", 1)
+                key = key.strip()
+                value = value.strip()
+                # Remove quotes
+                if value.startswith('"') and value.endswith('"'):
+                    value = value[1:-1]
+                elif value.startswith("'") and value.endswith("'"):
+                    value = value[1:-1]
+                # Handle null
+                if value == "null":
+                    value = None
+                frontmatter[key] = value
+        else:
+            # No frontmatter, try to get title from first heading
+            break
+
+    # If no title in frontmatter, extract from first heading
+    if "title" not in frontmatter:
+        for line in lines:
+            if line.startswith("# "):
+                frontmatter["title"] = line[2:].strip()
+                break
+
+    return frontmatter
+
+
+def load_plans(workspace_dir: Path) -> list[PlanEntry]:
+    """Load plans from the plans directory."""
+    plans_dir = workspace_dir / "plans"
+    if not plans_dir.exists():
+        return []
+
+    plans = []
+    for project_dir in plans_dir.iterdir():
+        if not project_dir.is_dir():
+            continue
+
+        project = project_dir.name
+        for plan_file in project_dir.glob("*.md"):
+            try:
+                fm = parse_plan_frontmatter(plan_file)
+                plans.append(PlanEntry(
+                    file_path=plan_file,
+                    project=project,
+                    title=fm.get("title", plan_file.stem),
+                    issue=fm.get("issue"),
+                    status=fm.get("status", "draft"),
+                ))
+            except Exception:
+                continue
+
+    # Sort by project, then status (active first), then title
+    status_order = {"active": 0, "in_progress": 1, "draft": 2, "completed": 3}
+    plans.sort(key=lambda p: (p.project, status_order.get(p.status, 4), p.title))
+
+    return plans


### PR DESCRIPTION
## Summary
- Press `p` to open plans browser modal
- Shows all plans from `~/Projects/plans/` with project, title, status, issue number
- Press `o` to open the linked GitHub issue in browser
- Plans sorted by project, status, title
- Vim-style navigation (j/k) in modal

## Screenshot
Plans modal shows:
- Status indicator (green=active, yellow=in_progress, dim=draft, blue=completed)
- Plan title (truncated at 40 chars)
- Project name
- Issue number (if linked)

## Test plan
- [x] Press `p` opens plans modal
- [x] Plans load from filesystem
- [x] Navigation works (j/k)
- [x] Press `o` opens issue in browser
- [x] Escape closes modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)