### PR TITLE
Document plan sync and TUI plans browser

### DIFF
--- a/CLAUDE.md.snippet
+++ b/CLAUDE.md.snippet
@@ -27,7 +27,19 @@ worktree-list                        # View all worktrees
 worktree-new myrepo feature-branch   # Create worktree
 worktree-cleanup myrepo feature-branch  # Remove after merge
 worktree-sync                        # Rebuild manifest from git
+plan-sync                            # Sync plans to GitHub issues
 ```
+
+## Plan Sync
+
+Plans in `~/Projects/plans/<project>/*.md` sync to GitHub issues:
+- Add `github_repo` and `github_issue` frontmatter to link
+- `plan-sync` pushes local changes or pulls remote updates
+- `plan-sync --dry-run` previews changes
+
+## TUI
+
+Run `bearing-tui` to browse projects, worktrees, and plans visually. Press `p` for plans, `o` to open PRs/issues.
 
 ## Recovery
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,51 @@ For when you want to run things manually:
 | `bearing worktree list` | See all worktrees |
 | `bearing worktree cleanup myapp feature` | Remove after merge |
 | `bearing worktree status` | Health check (dirty, PRs) |
+| `bearing plan sync` | Sync plans to/from GitHub issues |
 | `bearing-tui` | Launch the terminal UI |
+
+---
+
+## 📋 Plan Sync
+
+Track feature plans as markdown files and sync them to GitHub issues.
+
+```
+~/Projects/plans/
+├── myapp/
+│   ├── 001-auth-refactor.md    # Links to issue #42
+│   └── 002-api-redesign.md     # Links to issue #43
+└── api-server/
+    └── 001-graphql.md
+```
+
+**Plan frontmatter:**
+```yaml
+---
+title: Auth Refactor
+github_repo: user/myapp
+github_issue: 42
+status: active
+---
+```
+
+**Commands:**
+- `bearing plan sync` — Bidirectional sync (newer wins)
+- `bearing plan sync --prefer-remote` — Remote changes win conflicts
+- `bearing plan sync --dry-run` — Preview changes
+
+---
+
+## 🖥️ TUI Features
+
+Press `p` in the TUI to browse plans. Press `o` to open the linked GitHub issue.
+
+**Keybindings:**
+- `0/1/2` — Focus panels
+- `j/k` — Navigate
+- `p` — Plans browser
+- `o` — Open PR/issue
+- `?` — Help
 
 ---
 

--- a/tui/README.md
+++ b/tui/README.md
@@ -65,6 +65,8 @@ Press `?` for full keybinding help.
 | `c` | Cleanup worktree |
 | `r` | Refresh data |
 | `d` | Toggle daemon |
+| `p` | Plans browser |
+| `o` | Open PR in browser |
 | `?` | Show help |
 | `q` | Quit |
 
@@ -108,9 +110,25 @@ async def test_keyboard_navigation(workspace):
         assert isinstance(app.focused, WorktreeTable)
 ```
 
+## Plans Browser
+
+Press `p` to open the plans browser. Plans are loaded from `~/Projects/plans/<project>/*.md`.
+
+**Plan frontmatter:**
+```yaml
+---
+title: Feature Name
+github_repo: user/repo
+github_issue: 42
+status: active
+---
+```
+
+Press `o` in the plans browser to open the linked GitHub issue.
+
 ## Architecture
 
 - **app.py** - Main Textual App with layout and keybindings
 - **state.py** - Reads JSONL state files, auto-detects workspace
-- **widgets/** - Reusable Textual widgets (ProjectList, WorktreeTable, DetailsPanel)
+- **widgets/** - Reusable Textual widgets (ProjectList, WorktreeTable, DetailsPanel, PlansList)
 - **styles/app.tcss** - Textual CSS for Darcula-inspired theme


### PR DESCRIPTION
## Summary
- Add documentation for plan sync feature (`bearing plan sync`)
- Document TUI plans browser (`p` key) and open PR/issue (`o` key)
- Update CLAUDE.md.snippet with plan sync commands

## Test plan
- [ ] Review README changes render correctly
- [ ] Verify plan sync documentation matches script behavior
- [ ] Check TUI keybinding table is accurate

Generated with [Claude Code](https://claude.com/claude-code)