### PR TITLE
Add PR browser to TUI

### DIFF
--- a/tui/bearing_tui/state.py
+++ b/tui/bearing_tui/state.py
@@ -55,6 +55,21 @@ class HealthEntry:
     last_check: Optional[datetime]
 
 
+@dataclass
+class PREntry:
+    """Represents a GitHub PR from prs.jsonl."""
+    repo: str
+    number: int
+    title: str
+    state: str  # OPEN, CLOSED, MERGED
+    branch: str
+    base_branch: str
+    author: str
+    updated: Optional[datetime]
+    checks: Optional[str]  # SUCCESS, FAILURE, PENDING, None
+    draft: bool = False
+
+
 def _parse_datetime(value: Optional[str]) -> Optional[datetime]:
     """Parse ISO format datetime, handling 'unknown' and None."""
     if not value or value == "unknown":
@@ -146,6 +161,53 @@ class BearingState:
     def get_workflow_for_branch(self, repo: str, branch: str) -> Optional[WorkflowEntry]:
         """Get workflow entry for a repo/branch."""
         for entry in self.read_workflow():
+            if entry.repo == repo and entry.branch == branch:
+                return entry
+        return None
+
+    def read_prs(self) -> list[PREntry]:
+        """Read prs.jsonl - cached PR data."""
+        entries = _read_jsonl(self.workspace_dir / "prs.jsonl")
+        return [
+            PREntry(
+                repo=e["repo"],
+                number=e["number"],
+                title=e.get("title", ""),
+                state=e.get("state", "OPEN"),
+                branch=e.get("branch", ""),
+                base_branch=e.get("baseBranch", "main"),
+                author=e.get("author", ""),
+                updated=_parse_datetime(e.get("updated")),
+                checks=e.get("checks"),
+                draft=e.get("draft", False),
+            )
+            for e in entries
+        ]
+
+    def get_prs_for_project(self, repo: str) -> list[PREntry]:
+        """Get PRs for a specific repo, sorted: open first, then by updated."""
+        prs = [p for p in self.read_prs() if p.repo == repo]
+        # Sort: OPEN first, then by updated (newest first)
+        state_order = {"OPEN": 0, "DRAFT": 1, "MERGED": 2, "CLOSED": 3}
+        prs.sort(key=lambda p: (
+            state_order.get(p.state, 4),
+            -(p.updated.timestamp() if p.updated else 0)
+        ))
+        return prs
+
+    def get_all_prs(self) -> list[PREntry]:
+        """Get all PRs, sorted: open first, then by updated."""
+        prs = self.read_prs()
+        state_order = {"OPEN": 0, "DRAFT": 1, "MERGED": 2, "CLOSED": 3}
+        prs.sort(key=lambda p: (
+            state_order.get(p.state, 4),
+            -(p.updated.timestamp() if p.updated else 0)
+        ))
+        return prs
+
+    def get_worktree_for_branch(self, repo: str, branch: str) -> Optional[LocalEntry]:
+        """Find worktree that matches a branch."""
+        for entry in self.read_local():
             if entry.repo == repo and entry.branch == branch:
                 return entry
         return None

--- a/tui/bearing_tui/styles/app.tcss
+++ b/tui/bearing_tui/styles/app.tcss
@@ -286,3 +286,54 @@ PlansList:focus PlanListItem.-highlight {
     color: $text-bright;
     text-style: bold;
 }
+
+/* PRs modal styling */
+PRsScreen {
+    align: center middle;
+}
+
+#prs-modal {
+    width: 90;
+    height: auto;
+    max-height: 80%;
+    background: $bg-panel;
+    border: round $accent-green;
+    padding: 1 2;
+}
+
+#prs-header {
+    height: 1;
+    margin-bottom: 1;
+}
+
+PRsTable {
+    background: $bg-panel;
+    height: auto;
+    max-height: 20;
+    border: none;
+}
+
+PRsTable > .datatable--header {
+    background: $bg-surface;
+    color: $accent-green;
+    text-style: bold;
+}
+
+PRsTable:focus > .datatable--cursor {
+    background: #2d5a8a;
+    color: $text-bright;
+    text-style: bold;
+}
+
+PRsTable > .datatable--cursor {
+    background: $bg-selection;
+    color: $text;
+}
+
+PRsTable > .datatable--even-row {
+    background: $bg-panel;
+}
+
+PRsTable > .datatable--odd-row {
+    background: $bg-surface;
+}

--- a/tui/bearing_tui/widgets/__init__.py
+++ b/tui/bearing_tui/widgets/__init__.py
@@ -4,6 +4,7 @@ from .worktrees import WorktreeTable, WorktreeEntry, HealthEntry
 from .details import DetailsPanel, LocalEntry, WorkflowEntry
 from .details import HealthEntry as DetailsHealthEntry
 from .plans import PlansList, PlanEntry, load_plans
+from .prs import PRsTable, PRDisplayEntry
 
 __all__ = [
     "ProjectList",
@@ -16,4 +17,6 @@ __all__ = [
     "PlansList",
     "PlanEntry",
     "load_plans",
+    "PRsTable",
+    "PRDisplayEntry",
 ]

--- a/tui/bearing_tui/widgets/prs.py
+++ b/tui/bearing_tui/widgets/prs.py
@@ -1,0 +1,114 @@
+"""PR table widget for displaying GitHub PRs."""
+from dataclasses import dataclass
+from typing import NamedTuple
+
+from textual.widgets import DataTable
+from textual.message import Message
+
+
+@dataclass
+class PRDisplayEntry:
+    """PR data for display in the table."""
+    repo: str
+    number: int
+    title: str
+    state: str
+    branch: str
+    checks: str | None
+    worktree: str | None  # Linked worktree folder if branch matches
+
+
+class PRsTable(DataTable):
+    """Table showing GitHub PRs."""
+
+    class PRSelected(Message):
+        """Emitted when a PR row is selected."""
+        def __init__(self, repo: str, number: int) -> None:
+            self.repo = repo
+            self.number = number
+            super().__init__()
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.cursor_type = "row"
+        self._prs: list[PRDisplayEntry] = []
+
+    def _setup_columns(self) -> None:
+        """Add table columns."""
+        self.add_columns("#", "Title", "State", "Branch", "Checks", "Worktree")
+
+    def on_mount(self) -> None:
+        """Set up table when mounted."""
+        self._setup_columns()
+
+    def set_prs(self, prs: list[PRDisplayEntry]) -> None:
+        """Update table with PR data."""
+        self._prs = prs
+        self.clear()
+
+        if not prs:
+            self.add_row("No PRs", "", "", "", "", "", key="empty")
+            return
+
+        for pr in prs:
+            # Format state with color indicators
+            state_display = {
+                "OPEN": "[green]OPEN[/]",
+                "DRAFT": "[dim]DRAFT[/]",
+                "MERGED": "[magenta]MERGED[/]",
+                "CLOSED": "[red]CLOSED[/]",
+            }.get(pr.state, pr.state)
+
+            # Format checks
+            checks_display = {
+                "SUCCESS": "[green]\u2713[/]",
+                "FAILURE": "[red]\u2717[/]",
+                "PENDING": "[yellow]\u25cf[/]",
+            }.get(pr.checks or "", "-")
+
+            # Truncate title
+            title = (pr.title[:35] + "...") if len(pr.title) > 38 else pr.title
+
+            # Worktree indicator
+            wt = pr.worktree or "-"
+
+            self.add_row(
+                str(pr.number),
+                title,
+                state_display,
+                pr.branch[:20],
+                checks_display,
+                wt,
+                key=f"{pr.repo}:{pr.number}"
+            )
+
+    def on_data_table_row_selected(self, event: DataTable.RowSelected) -> None:
+        """Handle row selection."""
+        if event.row_key and str(event.row_key.value) != "empty":
+            key = str(event.row_key.value)
+            if ":" in key:
+                repo, num = key.rsplit(":", 1)
+                self.post_message(self.PRSelected(repo, int(num)))
+
+    def clear_prs(self) -> None:
+        """Clear the table."""
+        self.clear()
+        self._prs = []
+        self.add_row("Press 'r' to view PRs", "", "", "", "", "", key="empty")
+
+    def get_selected_pr(self) -> PRDisplayEntry | None:
+        """Get the currently selected PR."""
+        if not self._prs or self.row_count == 0:
+            return None
+        try:
+            from textual.coordinate import Coordinate
+            cell_key = self.coordinate_to_cell_key(Coordinate(self.cursor_row, 0))
+            key = str(cell_key.row_key.value)
+            if key == "empty":
+                return None
+            for pr in self._prs:
+                if f"{pr.repo}:{pr.number}" == key:
+                    return pr
+        except Exception:
+            pass
+        return None

--- a/tui/tests/conftest.py
+++ b/tui/tests/conftest.py
@@ -9,6 +9,7 @@ from tests.mock_data import (
     create_overflow_workspace,
     create_long_names_workspace,
     create_single_workspace,
+    create_prs_workspace,
 )
 
 
@@ -48,6 +49,14 @@ def long_names_workspace():
 def single_workspace():
     """Create a workspace with a single project and worktree."""
     path = create_single_workspace()
+    yield path
+    shutil.rmtree(path, ignore_errors=True)
+
+
+@pytest.fixture
+def prs_workspace():
+    """Create a workspace with PR data for testing."""
+    path = create_prs_workspace()
     yield path
     shutil.rmtree(path, ignore_errors=True)
 

--- a/tui/tests/mock_data/__init__.py
+++ b/tui/tests/mock_data/__init__.py
@@ -5,6 +5,7 @@ from .scenarios import (
     create_overflow_workspace,
     create_long_names_workspace,
     create_single_workspace,
+    create_prs_workspace,
     SCENARIOS,
 )
 
@@ -14,5 +15,6 @@ __all__ = [
     "create_overflow_workspace",
     "create_long_names_workspace",
     "create_single_workspace",
+    "create_prs_workspace",
     "SCENARIOS",
 ]

--- a/tui/tests/mock_data/scenarios.py
+++ b/tui/tests/mock_data/scenarios.py
@@ -280,6 +280,49 @@ def create_single_workspace() -> Path:
     return workspace
 
 
+def create_prs_workspace() -> Path:
+    """Create workspace with PR data for PR browser testing."""
+    workspace = Path(tempfile.mkdtemp(prefix="bearing_prs_"))
+
+    local_entries = [
+        {"folder": "acme-web", "repo": "acme-web", "branch": "main", "base": True},
+        {"folder": "acme-web-auth", "repo": "acme-web", "branch": "feature-auth", "base": False},
+        {"folder": "acme-web-checkout", "repo": "acme-web", "branch": "fix-checkout", "base": False},
+        {"folder": "acme-api", "repo": "acme-api", "branch": "main", "base": True},
+        {"folder": "acme-api-graphql", "repo": "acme-api", "branch": "graphql", "base": False},
+    ]
+
+    workflow_entries = [
+        {"repo": "acme-web", "branch": "feature-auth", "basedOn": "main", "purpose": "OAuth2 login", "status": "in_progress", "created": "2026-01-15T10:00:00Z"},
+        {"repo": "acme-web", "branch": "fix-checkout", "basedOn": "main", "purpose": "Fix cart bug", "status": "done", "created": "2026-01-18T14:30:00Z"},
+        {"repo": "acme-api", "branch": "graphql", "basedOn": "main", "purpose": "GraphQL layer", "status": "in_progress", "created": "2026-01-08T09:00:00Z"},
+    ]
+
+    health_entries = [
+        {"folder": "acme-web", "dirty": False, "unpushed": 0, "prState": None},
+        {"folder": "acme-web-auth", "dirty": True, "unpushed": 3, "prState": "OPEN"},
+        {"folder": "acme-web-checkout", "dirty": False, "unpushed": 0, "prState": "MERGED"},
+        {"folder": "acme-api", "dirty": False, "unpushed": 0, "prState": None},
+        {"folder": "acme-api-graphql", "dirty": True, "unpushed": 8, "prState": "OPEN"},
+    ]
+
+    prs_entries = [
+        {"repo": "acme-web", "number": 142, "title": "Add OAuth2 authentication flow", "state": "OPEN", "branch": "feature-auth", "baseBranch": "main", "author": "alice", "updated": "2026-01-19T18:00:00Z", "checks": "SUCCESS", "draft": False},
+        {"repo": "acme-web", "number": 138, "title": "Fix checkout cart calculation bug", "state": "MERGED", "branch": "fix-checkout", "baseBranch": "main", "author": "bob", "updated": "2026-01-19T12:00:00Z", "checks": "SUCCESS", "draft": False},
+        {"repo": "acme-web", "number": 145, "title": "Lazy load images", "state": "OPEN", "branch": "perf-images", "baseBranch": "main", "author": "alice", "updated": "2026-01-19T20:00:00Z", "checks": "PENDING", "draft": False},
+        {"repo": "acme-web", "number": 130, "title": "New design system v2", "state": "OPEN", "branch": "redesign-v2", "baseBranch": "main", "author": "carol", "updated": "2026-01-18T10:00:00Z", "checks": "FAILURE", "draft": True},
+        {"repo": "acme-api", "number": 89, "title": "Add GraphQL API layer", "state": "OPEN", "branch": "graphql", "baseBranch": "main", "author": "dave", "updated": "2026-01-19T16:00:00Z", "checks": "SUCCESS", "draft": False},
+        {"repo": "acme-api", "number": 85, "title": "Rate limiting middleware", "state": "MERGED", "branch": "rate-limit", "baseBranch": "main", "author": "eve", "updated": "2026-01-18T09:00:00Z", "checks": "SUCCESS", "draft": False},
+    ]
+
+    _write_jsonl(workspace / "local.jsonl", local_entries)
+    _write_jsonl(workspace / "workflow.jsonl", workflow_entries)
+    _write_jsonl(workspace / "health.jsonl", health_entries)
+    _write_jsonl(workspace / "prs.jsonl", prs_entries)
+
+    return workspace
+
+
 # Map scenario names to factory functions
 SCENARIOS: dict[str, Callable[[], Path]] = {
     "normal": create_normal_workspace,
@@ -287,4 +330,5 @@ SCENARIOS: dict[str, Callable[[], Path]] = {
     "overflow": create_overflow_workspace,
     "long_names": create_long_names_workspace,
     "single": create_single_workspace,
+    "prs": create_prs_workspace,
 }

--- a/tui/tests/test_prs.py
+++ b/tui/tests/test_prs.py
@@ -1,0 +1,87 @@
+"""Tests for PR browser functionality."""
+import pytest
+from bearing_tui.app import BearingApp, PRsScreen
+from bearing_tui.widgets import PRsTable
+
+
+@pytest.fixture
+def prs_app(prs_workspace):
+    """Create app with PR data."""
+    return BearingApp(workspace=prs_workspace)
+
+
+async def test_prs_modal_opens(prs_app):
+    """Test that R key opens the PRs modal."""
+    async with prs_app.run_test() as pilot:
+        await pilot.pause()
+        await pilot.press("R")
+        await pilot.pause()
+        # Check modal is shown
+        assert len(prs_app.screen_stack) > 1
+        assert isinstance(prs_app.screen, PRsScreen)
+
+
+async def test_prs_modal_shows_prs(prs_app):
+    """Test that PRs are displayed in the modal."""
+    async with prs_app.run_test() as pilot:
+        await pilot.pause()
+        await pilot.press("R")
+        await pilot.pause()
+        prs_table = prs_app.screen.query_one(PRsTable)
+        # Should have multiple rows (PRs)
+        assert prs_table.row_count > 0
+
+
+async def test_prs_modal_closes_on_escape(prs_app):
+    """Test that Escape closes the PRs modal."""
+    async with prs_app.run_test() as pilot:
+        await pilot.pause()
+        await pilot.press("R")
+        await pilot.pause()
+        await pilot.press("escape")
+        await pilot.pause()
+        # Should be back to main screen
+        assert len(prs_app.screen_stack) == 1
+
+
+async def test_prs_modal_navigation(prs_app):
+    """Test j/k navigation in PRs modal."""
+    async with prs_app.run_test() as pilot:
+        await pilot.pause()
+        await pilot.press("R")
+        await pilot.pause()
+        prs_table = prs_app.screen.query_one(PRsTable)
+        initial_cursor = prs_table.cursor_row
+        await pilot.press("j")
+        await pilot.pause()
+        assert prs_table.cursor_row == initial_cursor + 1
+        await pilot.press("k")
+        await pilot.pause()
+        assert prs_table.cursor_row == initial_cursor
+
+
+async def test_prs_sorted_open_first(prs_app):
+    """Test that OPEN PRs are sorted before MERGED."""
+    async with prs_app.run_test() as pilot:
+        await pilot.pause()
+        await pilot.press("R")
+        await pilot.pause()
+        prs_table = prs_app.screen.query_one(PRsTable)
+        # First PR should be OPEN (check display entry state)
+        if prs_table._prs:
+            # OPEN and DRAFT states come before MERGED/CLOSED
+            open_states = {"OPEN", "DRAFT"}
+            first_pr = prs_table._prs[0]
+            assert first_pr.state in open_states
+
+
+async def test_prs_shows_linked_worktree(prs_app):
+    """Test that PRs show linked worktree folder."""
+    async with prs_app.run_test() as pilot:
+        await pilot.pause()
+        await pilot.press("R")
+        await pilot.pause()
+        prs_table = prs_app.screen.query_one(PRsTable)
+        # Check that at least one PR has a linked worktree
+        has_worktree = any(pr.worktree for pr in prs_table._prs)
+        assert has_worktree, "Should have at least one PR with a linked worktree"


### PR DESCRIPTION
## Summary
- Add `prs.jsonl` cache format for offline PR data with PREntry dataclass
- Create PRsTable widget showing: PR number, title, state, branch, checks, linked worktree
- Add PRsScreen modal accessible via 'R' key with vim-style navigation
- PRs sorted: open first, then by updated date
- Shows linked worktree if branch matches a local worktree

## Test plan
- [x] Run `pytest tests/test_prs.py -v` - all 6 tests pass
- [x] Run `pytest tests/ -v` - all 54 tests pass
- [ ] Manual: Press 'R' to open PR browser
- [ ] Manual: Navigate with j/k, press 'o' to open PR in browser
- [ ] Manual: Press Escape to close modal

Generated with [Claude Code](https://claude.com/claude-code)