### PR TITLE
Web Dashboard: HTTP API and Vanilla JS Frontend

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -2,6 +2,8 @@ package daemon
 
 import (
 	"fmt"
+	"io/fs"
+	"net/http"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -14,17 +16,22 @@ import (
 	"github.com/joshribakoff/bearing/internal/jsonl"
 )
 
+// HTTPPort is the port the HTTP server listens on
+const HTTPPort = 8374
+
 // Config holds daemon configuration
 type Config struct {
 	WorkspaceDir string
 	BearingDir   string
 	Interval     time.Duration
+	StaticFS     fs.FS // Optional: embedded static files for web dashboard
 }
 
 // Daemon manages the health monitoring background process
 type Daemon struct {
-	config Config
-	stop   chan struct{}
+	config     Config
+	stop       chan struct{}
+	httpServer *HTTPServer
 }
 
 // New creates a new daemon instance
@@ -133,6 +140,18 @@ func (d *Daemon) run() error {
 		return err
 	}
 
+	// Start HTTP server for web dashboard
+	store := jsonl.NewStore(d.config.WorkspaceDir)
+	d.httpServer = NewHTTPServer(store, d.config.WorkspaceDir, d.config.StaticFS)
+
+	go func() {
+		addr := fmt.Sprintf(":%d", HTTPPort)
+		fmt.Printf("HTTP server listening on http://localhost%s\n", addr)
+		if err := http.ListenAndServe(addr, d.httpServer.Handler()); err != nil {
+			fmt.Printf("HTTP server error: %v\n", err)
+		}
+	}()
+
 	// Handle signals
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
@@ -193,6 +212,14 @@ func (d *Daemon) runHealthCheck() {
 
 	if err := store.WriteHealth(health); err != nil {
 		fmt.Printf("Error writing health.jsonl: %v\n", err)
+	}
+
+	// Broadcast update to connected web clients
+	if d.httpServer != nil {
+		d.httpServer.Broadcast("health", map[string]interface{}{
+			"timestamp":     time.Now(),
+			"worktreeCount": len(health),
+		})
 	}
 }
 

--- a/internal/daemon/http.go
+++ b/internal/daemon/http.go
@@ -1,0 +1,450 @@
+package daemon
+
+import (
+	"embed"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/joshribakoff/bearing/internal/jsonl"
+)
+
+// HTTPServer serves the web dashboard API and static files
+type HTTPServer struct {
+	store     *jsonl.Store
+	workspace string
+	mu        sync.RWMutex
+	staticFS  fs.FS
+	clients   map[chan []byte]bool
+	clientsMu sync.RWMutex
+}
+
+// NewHTTPServer creates a new HTTP server for the dashboard
+func NewHTTPServer(store *jsonl.Store, workspace string, staticFS fs.FS) *HTTPServer {
+	return &HTTPServer{
+		store:     store,
+		workspace: workspace,
+		staticFS:  staticFS,
+		clients:   make(map[chan []byte]bool),
+	}
+}
+
+// Handler returns the http.Handler for the server
+func (s *HTTPServer) Handler() http.Handler {
+	mux := http.NewServeMux()
+
+	// API endpoints
+	mux.HandleFunc("/api/projects", s.handleProjects)
+	mux.HandleFunc("/api/worktrees", s.handleWorktrees)
+	mux.HandleFunc("/api/plans", s.handlePlans)
+	mux.HandleFunc("/api/prs", s.handlePRs)
+	mux.HandleFunc("/api/health", s.handleHealth)
+	mux.HandleFunc("/api/status", s.handleStatus)
+	mux.HandleFunc("/api/events", s.handleEvents)
+
+	// Static files
+	if s.staticFS != nil {
+		fileServer := http.FileServer(http.FS(s.staticFS))
+		mux.Handle("/", fileServer)
+	}
+
+	return mux
+}
+
+// ProjectResponse for API
+type ProjectResponse struct {
+	Name  string `json:"name"`
+	Count int    `json:"count"`
+}
+
+func (s *HTTPServer) handleProjects(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	local, err := s.store.ReadLocal()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Count worktrees per repo
+	counts := make(map[string]int)
+	for _, e := range local {
+		counts[e.Repo]++
+	}
+
+	// Build unique project list with counts
+	projects := make([]ProjectResponse, 0)
+	seen := make(map[string]bool)
+	for _, e := range local {
+		if !seen[e.Repo] {
+			projects = append(projects, ProjectResponse{
+				Name:  e.Repo,
+				Count: counts[e.Repo],
+			})
+			seen[e.Repo] = true
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(projects)
+}
+
+// WorktreeResponse combines local and health data for API response
+type WorktreeResponse struct {
+	Folder   string  `json:"folder"`
+	Repo     string  `json:"repo"`
+	Branch   string  `json:"branch"`
+	Base     bool    `json:"base"`
+	Purpose  string  `json:"purpose,omitempty"`
+	Status   string  `json:"status,omitempty"`
+	Dirty    bool    `json:"dirty"`
+	Unpushed int     `json:"unpushed"`
+	PRState  *string `json:"prState,omitempty"`
+}
+
+func (s *HTTPServer) handleWorktrees(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	project := r.URL.Query().Get("project")
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	local, err := s.store.ReadLocal()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	workflow, _ := s.store.ReadWorkflow()
+	health, _ := s.store.ReadHealth()
+
+	// Build lookup maps
+	workflowMap := make(map[string]jsonl.WorkflowEntry)
+	for _, wf := range workflow {
+		key := wf.Repo + "/" + wf.Branch
+		workflowMap[key] = wf
+	}
+
+	healthMap := make(map[string]jsonl.HealthEntry)
+	for _, h := range health {
+		healthMap[h.Folder] = h
+	}
+
+	// Combine data - always return array, not null
+	resp := make([]WorktreeResponse, 0)
+	for _, l := range local {
+		if project != "" && l.Repo != project {
+			continue
+		}
+
+		wt := WorktreeResponse{
+			Folder: l.Folder,
+			Repo:   l.Repo,
+			Branch: l.Branch,
+			Base:   l.Base,
+		}
+
+		if wf, ok := workflowMap[l.Repo+"/"+l.Branch]; ok {
+			wt.Purpose = wf.Purpose
+			wt.Status = wf.Status
+		}
+
+		if h, ok := healthMap[l.Folder]; ok {
+			wt.Dirty = h.Dirty
+			wt.Unpushed = h.Unpushed
+			wt.PRState = h.PRState
+		}
+
+		resp = append(resp, wt)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+// PlanResponse for API
+type PlanResponse struct {
+	Project string `json:"project"`
+	Title   string `json:"title"`
+	Issue   string `json:"issue,omitempty"`
+	Status  string `json:"status"`
+	Path    string `json:"path"`
+}
+
+func (s *HTTPServer) handlePlans(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	plansDir := filepath.Join(s.workspace, "plans")
+	plans := make([]PlanResponse, 0)
+
+	filepath.WalkDir(plansDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() || !strings.HasSuffix(path, ".md") {
+			return nil
+		}
+
+		rel, _ := filepath.Rel(plansDir, path)
+		parts := strings.Split(rel, string(os.PathSeparator))
+		if len(parts) < 2 {
+			return nil
+		}
+
+		project := parts[0]
+		fm := parsePlanFrontmatter(path)
+
+		plans = append(plans, PlanResponse{
+			Project: project,
+			Title:   fm["title"],
+			Issue:   fm["issue"],
+			Status:  fm["status"],
+			Path:    rel,
+		})
+
+		return nil
+	})
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(plans)
+}
+
+// PRResponse for API
+type PRResponse struct {
+	Folder string `json:"folder"`
+	Repo   string `json:"repo"`
+	Branch string `json:"branch"`
+	State  string `json:"state"`
+}
+
+func (s *HTTPServer) handlePRs(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	health, err := s.store.ReadHealth()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	local, _ := s.store.ReadLocal()
+	localMap := make(map[string]jsonl.LocalEntry)
+	for _, e := range local {
+		localMap[e.Folder] = e
+	}
+
+	prs := make([]PRResponse, 0)
+	for _, h := range health {
+		if h.PRState == nil {
+			continue
+		}
+		if l, ok := localMap[h.Folder]; ok {
+			prs = append(prs, PRResponse{
+				Folder: h.Folder,
+				Repo:   l.Repo,
+				Branch: l.Branch,
+				State:  *h.PRState,
+			})
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(prs)
+}
+
+// HealthResponse for API
+type HealthResponse struct {
+	DaemonRunning bool      `json:"daemonRunning"`
+	LastCheck     time.Time `json:"lastCheck"`
+	WorktreeCount int       `json:"worktreeCount"`
+}
+
+func (s *HTTPServer) handleHealth(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	health, err := s.store.ReadHealth()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	var lastCheck time.Time
+	for _, h := range health {
+		if h.LastCheck.After(lastCheck) {
+			lastCheck = h.LastCheck
+		}
+	}
+
+	resp := HealthResponse{
+		DaemonRunning: true,
+		LastCheck:     lastCheck,
+		WorktreeCount: len(health),
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+// StatusResponse contains daemon status info
+type StatusResponse struct {
+	Running bool   `json:"running"`
+	Version string `json:"version"`
+}
+
+func (s *HTTPServer) handleStatus(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	resp := StatusResponse{
+		Running: true,
+		Version: "0.1.0",
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+// handleEvents implements Server-Sent Events for real-time updates
+func (s *HTTPServer) handleEvents(w http.ResponseWriter, r *http.Request) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "SSE not supported", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+
+	client := make(chan []byte, 10)
+	s.clientsMu.Lock()
+	s.clients[client] = true
+	s.clientsMu.Unlock()
+
+	defer func() {
+		s.clientsMu.Lock()
+		delete(s.clients, client)
+		s.clientsMu.Unlock()
+		close(client)
+	}()
+
+	// Send initial connected event
+	fmt.Fprintf(w, "event: connected\ndata: {\"status\":\"ok\"}\n\n")
+	flusher.Flush()
+
+	for {
+		select {
+		case msg := <-client:
+			fmt.Fprintf(w, "event: update\ndata: %s\n\n", msg)
+			flusher.Flush()
+		case <-r.Context().Done():
+			return
+		}
+	}
+}
+
+// Broadcast sends an event to all connected SSE clients
+func (s *HTTPServer) Broadcast(eventType string, data interface{}) {
+	msg, err := json.Marshal(map[string]interface{}{
+		"type": eventType,
+		"data": data,
+	})
+	if err != nil {
+		return
+	}
+
+	s.clientsMu.RLock()
+	defer s.clientsMu.RUnlock()
+
+	for client := range s.clients {
+		select {
+		case client <- msg:
+		default:
+			// Client buffer full, skip
+		}
+	}
+}
+
+// parsePlanFrontmatter parses YAML frontmatter from a plan file
+func parsePlanFrontmatter(path string) map[string]string {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return map[string]string{"title": filepath.Base(path)}
+	}
+
+	lines := strings.Split(string(content), "\n")
+	fm := make(map[string]string)
+	inFrontmatter := false
+
+	for i, line := range lines {
+		if strings.TrimSpace(line) == "---" {
+			if !inFrontmatter && i == 0 {
+				inFrontmatter = true
+				continue
+			} else if inFrontmatter {
+				break
+			}
+		} else if inFrontmatter {
+			if idx := strings.Index(line, ":"); idx > 0 {
+				key := strings.TrimSpace(line[:idx])
+				value := strings.TrimSpace(line[idx+1:])
+				value = strings.Trim(value, "\"'")
+				fm[key] = value
+			}
+		}
+	}
+
+	// Extract title from first heading if not in frontmatter
+	if fm["title"] == "" {
+		headingRe := regexp.MustCompile(`^#\s+(.+)$`)
+		for _, line := range lines {
+			if m := headingRe.FindStringSubmatch(line); len(m) > 1 {
+				fm["title"] = m[1]
+				break
+			}
+		}
+	}
+
+	if fm["title"] == "" {
+		fm["title"] = filepath.Base(path)
+	}
+	if fm["status"] == "" {
+		fm["status"] = "draft"
+	}
+
+	return fm
+}
+
+// EmbeddedStaticFS is a placeholder for the embedded web assets
+var EmbeddedStaticFS embed.FS

--- a/internal/daemon/http_test.go
+++ b/internal/daemon/http_test.go
@@ -1,0 +1,478 @@
+package daemon
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/joshribakoff/bearing/internal/jsonl"
+)
+
+func setupTestStore(t *testing.T) (*jsonl.Store, string) {
+	t.Helper()
+	dir := t.TempDir()
+
+	// Create test local.jsonl
+	localPath := filepath.Join(dir, "local.jsonl")
+	localData := `{"folder":"project-main","repo":"project","branch":"main","base":true}
+{"folder":"project-feature","repo":"project","branch":"feature-1","base":false}
+`
+	if err := os.WriteFile(localPath, []byte(localData), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create test health.jsonl
+	healthPath := filepath.Join(dir, "health.jsonl")
+	healthData := `{"folder":"project-main","dirty":false,"unpushed":0,"lastCheck":"2024-01-01T00:00:00Z"}
+{"folder":"project-feature","dirty":true,"unpushed":2,"prState":"OPEN","lastCheck":"2024-01-01T00:00:00Z"}
+`
+	if err := os.WriteFile(healthPath, []byte(healthData), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create test projects.jsonl
+	projectsPath := filepath.Join(dir, "projects.jsonl")
+	projectsData := `{"name":"project","github_repo":"user/project","path":"/path/to/project"}
+`
+	if err := os.WriteFile(projectsPath, []byte(projectsData), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	return jsonl.NewStore(dir), dir
+}
+
+func TestHandleWorktrees(t *testing.T) {
+	store, dir := setupTestStore(t)
+	server := NewHTTPServer(store, dir, nil)
+	handler := server.Handler()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/worktrees", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rec.Code)
+	}
+
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("expected Content-Type application/json, got %s", ct)
+	}
+
+	var resp []WorktreeResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if len(resp) != 2 {
+		t.Fatalf("expected 2 worktrees, got %d", len(resp))
+	}
+
+	// Check first worktree (base)
+	if resp[0].Folder != "project-main" {
+		t.Errorf("expected folder project-main, got %s", resp[0].Folder)
+	}
+	if !resp[0].Base {
+		t.Error("expected first worktree to be base")
+	}
+	if resp[0].Dirty {
+		t.Error("expected first worktree to not be dirty")
+	}
+
+	// Check second worktree (feature)
+	if resp[1].Folder != "project-feature" {
+		t.Errorf("expected folder project-feature, got %s", resp[1].Folder)
+	}
+	if resp[1].Base {
+		t.Error("expected second worktree to not be base")
+	}
+	if !resp[1].Dirty {
+		t.Error("expected second worktree to be dirty")
+	}
+	if resp[1].Unpushed != 2 {
+		t.Errorf("expected 2 unpushed, got %d", resp[1].Unpushed)
+	}
+	if resp[1].PRState == nil || *resp[1].PRState != "OPEN" {
+		t.Error("expected PRState to be OPEN")
+	}
+}
+
+func TestHandleWorktrees_MethodNotAllowed(t *testing.T) {
+	store, dir := setupTestStore(t)
+	server := NewHTTPServer(store, dir, nil)
+	handler := server.Handler()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/worktrees", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected status 405, got %d", rec.Code)
+	}
+}
+
+func TestHandleWorktrees_FilterByProject(t *testing.T) {
+	store, dir := setupTestStore(t)
+	server := NewHTTPServer(store, dir, nil)
+	handler := server.Handler()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/worktrees?project=project", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rec.Code)
+	}
+
+	var resp []WorktreeResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if len(resp) != 2 {
+		t.Fatalf("expected 2 worktrees for project, got %d", len(resp))
+	}
+
+	// Test with non-existent project
+	req = httptest.NewRequest(http.MethodGet, "/api/worktrees?project=nonexistent", nil)
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if len(resp) != 0 {
+		t.Errorf("expected 0 worktrees for nonexistent project, got %d", len(resp))
+	}
+}
+
+func TestHandleHealth(t *testing.T) {
+	store, dir := setupTestStore(t)
+	server := NewHTTPServer(store, dir, nil)
+	handler := server.Handler()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/health", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rec.Code)
+	}
+
+	var resp HealthResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if !resp.DaemonRunning {
+		t.Error("expected daemon running to be true")
+	}
+	if resp.WorktreeCount != 2 {
+		t.Errorf("expected 2 worktrees, got %d", resp.WorktreeCount)
+	}
+}
+
+func TestHandleProjects(t *testing.T) {
+	store, dir := setupTestStore(t)
+	server := NewHTTPServer(store, dir, nil)
+	handler := server.Handler()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/projects", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rec.Code)
+	}
+
+	var resp []ProjectResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if len(resp) != 1 {
+		t.Fatalf("expected 1 project, got %d", len(resp))
+	}
+
+	if resp[0].Name != "project" {
+		t.Errorf("expected project name 'project', got %s", resp[0].Name)
+	}
+	if resp[0].Count != 2 {
+		t.Errorf("expected count 2, got %d", resp[0].Count)
+	}
+}
+
+func TestHandlePRs(t *testing.T) {
+	store, dir := setupTestStore(t)
+	server := NewHTTPServer(store, dir, nil)
+	handler := server.Handler()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/prs", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rec.Code)
+	}
+
+	var resp []PRResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	// Only project-feature has a PR
+	if len(resp) != 1 {
+		t.Fatalf("expected 1 PR, got %d", len(resp))
+	}
+
+	if resp[0].State != "OPEN" {
+		t.Errorf("expected PR state OPEN, got %s", resp[0].State)
+	}
+}
+
+func TestHandlePlans(t *testing.T) {
+	store, dir := setupTestStore(t)
+
+	// Create plans directory with a test plan
+	plansDir := filepath.Join(dir, "plans", "testproject")
+	if err := os.MkdirAll(plansDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	planContent := `---
+title: Test Plan
+status: active
+issue: "#123"
+---
+
+# Test Plan
+
+This is a test plan.
+`
+	if err := os.WriteFile(filepath.Join(plansDir, "001-test.md"), []byte(planContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	server := NewHTTPServer(store, dir, nil)
+	handler := server.Handler()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/plans", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rec.Code)
+	}
+
+	var resp []PlanResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if len(resp) != 1 {
+		t.Fatalf("expected 1 plan, got %d", len(resp))
+	}
+
+	if resp[0].Title != "Test Plan" {
+		t.Errorf("expected title 'Test Plan', got %s", resp[0].Title)
+	}
+	if resp[0].Status != "active" {
+		t.Errorf("expected status 'active', got %s", resp[0].Status)
+	}
+	if resp[0].Project != "testproject" {
+		t.Errorf("expected project 'testproject', got %s", resp[0].Project)
+	}
+}
+
+func TestHandleStatus(t *testing.T) {
+	store, dir := setupTestStore(t)
+	server := NewHTTPServer(store, dir, nil)
+	handler := server.Handler()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/status", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rec.Code)
+	}
+
+	var resp StatusResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if !resp.Running {
+		t.Error("expected running to be true")
+	}
+	if resp.Version == "" {
+		t.Error("expected version to be set")
+	}
+}
+
+func TestStaticFileServing(t *testing.T) {
+	store, dir := setupTestStore(t)
+
+	// Create static files
+	staticDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(staticDir, "index.html"), []byte("<!DOCTYPE html><html><body>Hello</body></html>"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(staticDir, "app.js"), []byte("console.log('hello');"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	server := NewHTTPServer(store, dir, os.DirFS(staticDir))
+
+	// Use httptest.Server for proper request handling
+	ts := httptest.NewServer(server.Handler())
+	defer ts.Close()
+
+	// Test index.html
+	resp, err := http.Get(ts.URL + "/index.html")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected status 200, got %d", resp.StatusCode)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "<!DOCTYPE html><html><body>Hello</body></html>" {
+		t.Errorf("unexpected body: %s", string(body))
+	}
+
+	// Test app.js
+	resp2, err := http.Get(ts.URL + "/app.js")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp2.Body.Close()
+
+	if resp2.StatusCode != http.StatusOK {
+		t.Errorf("expected status 200, got %d", resp2.StatusCode)
+	}
+}
+
+func TestEmptyStore(t *testing.T) {
+	// Test with empty directory (no JSONL files)
+	dir := t.TempDir()
+	store := jsonl.NewStore(dir)
+	server := NewHTTPServer(store, dir, nil)
+	handler := server.Handler()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/worktrees", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rec.Code)
+	}
+
+	var resp []WorktreeResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	// Should return empty array, not null
+	if len(resp) != 0 {
+		t.Errorf("expected empty array, got %d items", len(resp))
+	}
+}
+
+func TestHandleEvents_SSE(t *testing.T) {
+	store, dir := setupTestStore(t)
+	server := NewHTTPServer(store, dir, nil)
+
+	ts := httptest.NewServer(server.Handler())
+	defer ts.Close()
+
+	// Make SSE request
+	resp, err := http.Get(ts.URL + "/api/events")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected status 200, got %d", resp.StatusCode)
+	}
+
+	if ct := resp.Header.Get("Content-Type"); ct != "text/event-stream" {
+		t.Errorf("expected Content-Type text/event-stream, got %s", ct)
+	}
+
+	// Read initial connected event
+	buf := make([]byte, 1024)
+	n, err := resp.Body.Read(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	data := string(buf[:n])
+	if !contains(data, "event: connected") {
+		t.Errorf("expected connected event, got: %s", data)
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsAt(s, substr, 0))
+}
+
+func containsAt(s, substr string, start int) bool {
+	for i := start; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}
+
+func TestParsePlanFrontmatter(t *testing.T) {
+	dir := t.TempDir()
+
+	// Test with frontmatter
+	planWithFM := `---
+title: My Plan
+status: active
+issue: "#42"
+---
+
+# Content
+`
+	path1 := filepath.Join(dir, "plan1.md")
+	if err := os.WriteFile(path1, []byte(planWithFM), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	fm := parsePlanFrontmatter(path1)
+	if fm["title"] != "My Plan" {
+		t.Errorf("expected title 'My Plan', got %s", fm["title"])
+	}
+	if fm["status"] != "active" {
+		t.Errorf("expected status 'active', got %s", fm["status"])
+	}
+
+	// Test without frontmatter (extract from heading)
+	planNoFM := `# Heading Title
+
+Some content.
+`
+	path2 := filepath.Join(dir, "plan2.md")
+	if err := os.WriteFile(path2, []byte(planNoFM), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	fm2 := parsePlanFrontmatter(path2)
+	if fm2["title"] != "Heading Title" {
+		t.Errorf("expected title 'Heading Title', got %s", fm2["title"])
+	}
+	if fm2["status"] != "draft" {
+		t.Errorf("expected default status 'draft', got %s", fm2["status"])
+	}
+}

--- a/internal/jsonl/store.go
+++ b/internal/jsonl/store.go
@@ -32,6 +32,11 @@ func (s *Store) HealthPath() string {
 	return filepath.Join(s.baseDir, "health.jsonl")
 }
 
+// ProjectsPath returns the path to projects.jsonl
+func (s *Store) ProjectsPath() string {
+	return filepath.Join(s.baseDir, "projects.jsonl")
+}
+
 // ReadWorkflow reads all workflow entries
 func (s *Store) ReadWorkflow() ([]WorkflowEntry, error) {
 	return readJSONL[WorkflowEntry](s.WorkflowPath())
@@ -45,6 +50,11 @@ func (s *Store) ReadLocal() ([]LocalEntry, error) {
 // ReadHealth reads all health entries
 func (s *Store) ReadHealth() ([]HealthEntry, error) {
 	return readJSONL[HealthEntry](s.HealthPath())
+}
+
+// ReadProjects reads all project entries
+func (s *Store) ReadProjects() ([]ProjectEntry, error) {
+	return readJSONL[ProjectEntry](s.ProjectsPath())
 }
 
 // WriteWorkflow writes all workflow entries (overwrites)

--- a/test/integration/http_test.go
+++ b/test/integration/http_test.go
@@ -1,0 +1,292 @@
+package integration
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/joshribakoff/bearing/internal/daemon"
+	"github.com/joshribakoff/bearing/internal/jsonl"
+)
+
+// TestHTTPServerIntegration tests the HTTP server with real JSONL files
+func TestHTTPServerIntegration(t *testing.T) {
+	// Create temp workspace
+	workspace := t.TempDir()
+
+	// Create realistic local.jsonl
+	localData := []jsonl.LocalEntry{
+		{Folder: "project-main", Repo: "project", Branch: "main", Base: true},
+		{Folder: "project-feature", Repo: "project", Branch: "feature/add-tests", Base: false},
+		{Folder: "other-main", Repo: "other", Branch: "main", Base: true},
+	}
+	writeJSONL(t, filepath.Join(workspace, "local.jsonl"), localData)
+
+	// Create realistic health.jsonl
+	healthData := []jsonl.HealthEntry{
+		{Folder: "project-main", Dirty: false, Unpushed: 0},
+		{Folder: "project-feature", Dirty: true, Unpushed: 3},
+		{Folder: "other-main", Dirty: false, Unpushed: 0},
+	}
+	writeJSONL(t, filepath.Join(workspace, "health.jsonl"), healthData)
+
+	// Create plans directory
+	plansDir := filepath.Join(workspace, "plans", "project")
+	if err := os.MkdirAll(plansDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	planContent := `---
+title: Add Testing Infrastructure
+status: in-progress
+issue: "#42"
+---
+
+# Add Testing Infrastructure
+
+This plan covers adding comprehensive tests.
+`
+	if err := os.WriteFile(filepath.Join(plansDir, "001-testing.md"), []byte(planContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create static files
+	staticDir := filepath.Join(workspace, "web")
+	if err := os.MkdirAll(staticDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	indexHTML := `<!DOCTYPE html>
+<html>
+<head><title>Bearing Dashboard</title></head>
+<body><h1>Bearing</h1></body>
+</html>`
+	if err := os.WriteFile(filepath.Join(staticDir, "index.html"), []byte(indexHTML), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create server
+	store := jsonl.NewStore(workspace)
+	server := daemon.NewHTTPServer(store, workspace, os.DirFS(staticDir))
+	ts := httptest.NewServer(server.Handler())
+	defer ts.Close()
+
+	t.Run("serves index.html", func(t *testing.T) {
+		resp, err := http.Get(ts.URL + "/index.html")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("expected 200, got %d", resp.StatusCode)
+		}
+
+		body, _ := io.ReadAll(resp.Body)
+		if len(body) == 0 {
+			t.Error("expected non-empty body")
+		}
+		if !contains(string(body), "Bearing") {
+			t.Error("expected body to contain 'Bearing'")
+		}
+	})
+
+	t.Run("worktrees returns combined data", func(t *testing.T) {
+		resp, err := http.Get(ts.URL + "/api/worktrees")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		var worktrees []daemon.WorktreeResponse
+		if err := json.NewDecoder(resp.Body).Decode(&worktrees); err != nil {
+			t.Fatal(err)
+		}
+
+		if len(worktrees) != 3 {
+			t.Fatalf("expected 3 worktrees, got %d", len(worktrees))
+		}
+
+		// Find feature worktree and check health data is merged
+		for _, wt := range worktrees {
+			if wt.Folder == "project-feature" {
+				if !wt.Dirty {
+					t.Error("expected project-feature to be dirty")
+				}
+				if wt.Unpushed != 3 {
+					t.Errorf("expected 3 unpushed, got %d", wt.Unpushed)
+				}
+			}
+		}
+	})
+
+	t.Run("worktrees filters by project", func(t *testing.T) {
+		resp, err := http.Get(ts.URL + "/api/worktrees?project=project")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		var worktrees []daemon.WorktreeResponse
+		if err := json.NewDecoder(resp.Body).Decode(&worktrees); err != nil {
+			t.Fatal(err)
+		}
+
+		if len(worktrees) != 2 {
+			t.Fatalf("expected 2 worktrees for 'project', got %d", len(worktrees))
+		}
+
+		for _, wt := range worktrees {
+			if wt.Repo != "project" {
+				t.Errorf("expected repo 'project', got '%s'", wt.Repo)
+			}
+		}
+	})
+
+	t.Run("projects returns unique projects with counts", func(t *testing.T) {
+		resp, err := http.Get(ts.URL + "/api/projects")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		var projects []daemon.ProjectResponse
+		if err := json.NewDecoder(resp.Body).Decode(&projects); err != nil {
+			t.Fatal(err)
+		}
+
+		if len(projects) != 2 {
+			t.Fatalf("expected 2 projects, got %d", len(projects))
+		}
+
+		// Check counts
+		for _, p := range projects {
+			if p.Name == "project" && p.Count != 2 {
+				t.Errorf("expected count 2 for 'project', got %d", p.Count)
+			}
+			if p.Name == "other" && p.Count != 1 {
+				t.Errorf("expected count 1 for 'other', got %d", p.Count)
+			}
+		}
+	})
+
+	t.Run("plans returns plan list", func(t *testing.T) {
+		resp, err := http.Get(ts.URL + "/api/plans")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		var plans []daemon.PlanResponse
+		if err := json.NewDecoder(resp.Body).Decode(&plans); err != nil {
+			t.Fatal(err)
+		}
+
+		if len(plans) != 1 {
+			t.Fatalf("expected 1 plan, got %d", len(plans))
+		}
+
+		if plans[0].Title != "Add Testing Infrastructure" {
+			t.Errorf("expected title 'Add Testing Infrastructure', got '%s'", plans[0].Title)
+		}
+		if plans[0].Status != "in-progress" {
+			t.Errorf("expected status 'in-progress', got '%s'", plans[0].Status)
+		}
+	})
+
+	t.Run("health returns aggregated health", func(t *testing.T) {
+		resp, err := http.Get(ts.URL + "/api/health")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		var health daemon.HealthResponse
+		if err := json.NewDecoder(resp.Body).Decode(&health); err != nil {
+			t.Fatal(err)
+		}
+
+		if !health.DaemonRunning {
+			t.Error("expected daemon running to be true")
+		}
+		if health.WorktreeCount != 3 {
+			t.Errorf("expected 3 worktrees, got %d", health.WorktreeCount)
+		}
+	})
+}
+
+// TestHTTPServerEmptyWorkspace tests behavior with no data
+func TestHTTPServerEmptyWorkspace(t *testing.T) {
+	workspace := t.TempDir()
+	store := jsonl.NewStore(workspace)
+	server := daemon.NewHTTPServer(store, workspace, nil)
+	ts := httptest.NewServer(server.Handler())
+	defer ts.Close()
+
+	t.Run("worktrees returns empty array", func(t *testing.T) {
+		resp, err := http.Get(ts.URL + "/api/worktrees")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		body, _ := io.ReadAll(resp.Body)
+		// Should be empty array, not null
+		if string(body) != "[]\n" {
+			t.Errorf("expected '[]\\n', got '%s'", string(body))
+		}
+	})
+
+	t.Run("projects returns empty array", func(t *testing.T) {
+		resp, err := http.Get(ts.URL + "/api/projects")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		body, _ := io.ReadAll(resp.Body)
+		if string(body) != "[]\n" {
+			t.Errorf("expected '[]\\n', got '%s'", string(body))
+		}
+	})
+
+	t.Run("plans returns empty array", func(t *testing.T) {
+		resp, err := http.Get(ts.URL + "/api/plans")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		body, _ := io.ReadAll(resp.Body)
+		if string(body) != "[]\n" {
+			t.Errorf("expected '[]\\n', got '%s'", string(body))
+		}
+	})
+}
+
+func writeJSONL[T any](t *testing.T, path string, entries []T) {
+	t.Helper()
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	enc := json.NewEncoder(f)
+	for _, e := range entries {
+		if err := enc.Encode(e); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func contains(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/web/app.js
+++ b/web/app.js
@@ -1,0 +1,538 @@
+// Bearing Web Dashboard - Vanilla JS Application
+
+const API_BASE = '';
+
+// State
+const state = {
+  projects: [],
+  worktrees: [],
+  plans: [],
+  selectedProject: null,
+  selectedWorktree: null,
+  selectedPlan: null,
+  focusedPanel: 'project-list',
+  projectIndex: 0,
+  worktreeIndex: 0,
+  planIndex: 0,
+  evtSource: null,
+};
+
+// DOM elements
+const els = {
+  projectList: null,
+  worktreeRows: null,
+  detailsContent: null,
+  statusIndicator: null,
+  helpModal: null,
+  plansModal: null,
+  plansList: null,
+};
+
+// Initialize
+document.addEventListener('DOMContentLoaded', init);
+
+function init() {
+  // Cache DOM elements
+  els.projectList = document.getElementById('project-list');
+  els.worktreeRows = document.getElementById('worktree-rows');
+  els.detailsContent = document.getElementById('details-content');
+  els.statusIndicator = document.getElementById('status-indicator');
+  els.helpModal = document.getElementById('help-modal');
+  els.plansModal = document.getElementById('plans-modal');
+  els.plansList = document.getElementById('plans-list');
+
+  // Setup event listeners
+  setupKeyboardNavigation();
+  setupClickHandlers();
+  connectSSE();
+
+  // Initial data load
+  refresh();
+}
+
+// Data fetching
+async function fetchJSON(url) {
+  const resp = await fetch(API_BASE + url);
+  if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+  return resp.json();
+}
+
+async function refresh() {
+  try {
+    const [projects, worktrees] = await Promise.all([
+      fetchJSON('/api/projects'),
+      fetchJSON('/api/worktrees'),
+    ]);
+
+    state.projects = projects || [];
+    state.worktrees = worktrees || [];
+
+    renderProjects();
+
+    // Restore selection or select first
+    if (state.selectedProject) {
+      const idx = state.projects.findIndex(p => p.name === state.selectedProject);
+      if (idx >= 0) {
+        state.projectIndex = idx;
+        selectProject(state.selectedProject);
+      } else if (state.projects.length > 0) {
+        state.projectIndex = 0;
+        selectProject(state.projects[0].name);
+      }
+    } else if (state.projects.length > 0) {
+      state.projectIndex = 0;
+      selectProject(state.projects[0].name);
+    }
+  } catch (err) {
+    console.error('Refresh failed:', err);
+    showError('Failed to load data');
+  }
+}
+
+async function loadPlans() {
+  try {
+    state.plans = await fetchJSON('/api/plans') || [];
+    renderPlans();
+  } catch (err) {
+    console.error('Failed to load plans:', err);
+  }
+}
+
+// Rendering
+function renderProjects() {
+  els.projectList.innerHTML = state.projects.map((p, i) => `
+    <li class="list-item ${i === state.projectIndex ? 'selected' : ''}"
+        data-project="${p.name}" data-index="${i}">
+      <span class="project-name">${escapeHtml(p.name)}</span>
+      <span class="project-count">${p.count}</span>
+    </li>
+  `).join('');
+}
+
+function renderWorktrees() {
+  const filtered = state.worktrees.filter(w => w.repo === state.selectedProject);
+
+  els.worktreeRows.innerHTML = filtered.map((w, i) => {
+    const statusParts = [];
+    if (w.dirty) statusParts.push('<span class="status-dirty">*</span>');
+    if (w.unpushed > 0) statusParts.push(`<span class="status-unpushed">${w.unpushed}↑</span>`);
+    if (!w.dirty && w.unpushed === 0) statusParts.push('<span class="status-clean">✓</span>');
+
+    let prBadge = '';
+    if (w.prState) {
+      const cls = `pr-${w.prState.toLowerCase()}`;
+      prBadge = `<span class="${cls}">${w.prState}</span>`;
+    }
+
+    const baseTag = w.base ? '<span class="base-indicator">BASE</span>' : '';
+
+    return `
+      <div class="table-row ${i === state.worktreeIndex ? 'selected' : ''}"
+           data-folder="${w.folder}" data-index="${i}">
+        <span class="col-folder">${escapeHtml(w.folder)}${baseTag}</span>
+        <span class="col-branch">${escapeHtml(w.branch)}</span>
+        <span class="col-status">${statusParts.join(' ')}</span>
+        <span class="col-pr">${prBadge}</span>
+      </div>
+    `;
+  }).join('');
+
+  // Update details if we have a selection
+  if (filtered.length > 0 && state.worktreeIndex < filtered.length) {
+    updateDetails(filtered[state.worktreeIndex]);
+  } else {
+    clearDetails();
+  }
+}
+
+function renderPlans() {
+  els.plansList.innerHTML = state.plans.map((p, i) => `
+    <div class="list-item ${i === state.planIndex ? 'selected' : ''}"
+         data-index="${i}" data-issue="${p.issue || ''}">
+      <span class="plan-status ${p.status}"></span>
+      <span class="plan-title">${escapeHtml(p.title)}</span>
+      <span class="plan-project">${escapeHtml(p.project)}</span>
+      <span class="plan-issue">${p.issue ? '#' + p.issue : ''}</span>
+    </div>
+  `).join('');
+}
+
+function updateDetails(worktree) {
+  if (!worktree) {
+    clearDetails();
+    return;
+  }
+
+  state.selectedWorktree = worktree;
+
+  const rows = [
+    { label: 'Folder:', value: worktree.folder },
+    { label: 'Repo:', value: worktree.repo },
+    { label: 'Branch:', value: worktree.branch },
+    { label: 'Base:', value: worktree.base ? 'Yes' : 'No' },
+  ];
+
+  if (worktree.purpose) {
+    rows.push({ label: 'Purpose:', value: worktree.purpose });
+  }
+  if (worktree.status) {
+    rows.push({ label: 'Status:', value: worktree.status });
+  }
+
+  const healthRow = [];
+  if (worktree.dirty) healthRow.push('Uncommitted changes');
+  if (worktree.unpushed > 0) healthRow.push(`${worktree.unpushed} unpushed`);
+  if (worktree.prState) healthRow.push(`PR: ${worktree.prState}`);
+  if (healthRow.length > 0) {
+    rows.push({ label: 'Health:', value: healthRow.join(', ') });
+  }
+
+  els.detailsContent.innerHTML = rows.map(r => `
+    <div class="detail-row">
+      <span class="detail-label">${r.label}</span>
+      <span class="detail-value">${escapeHtml(r.value)}</span>
+    </div>
+  `).join('');
+}
+
+function clearDetails() {
+  state.selectedWorktree = null;
+  els.detailsContent.innerHTML = '<span style="color: var(--text-dim)">Select a worktree to view details</span>';
+}
+
+// Selection
+function selectProject(name) {
+  state.selectedProject = name;
+  state.worktreeIndex = 0;
+
+  // Update project list selection
+  els.projectList.querySelectorAll('.list-item').forEach((el, i) => {
+    el.classList.toggle('selected', el.dataset.project === name);
+    if (el.dataset.project === name) state.projectIndex = i;
+  });
+
+  renderWorktrees();
+}
+
+function selectWorktree(index) {
+  const filtered = state.worktrees.filter(w => w.repo === state.selectedProject);
+  if (index < 0 || index >= filtered.length) return;
+
+  state.worktreeIndex = index;
+
+  els.worktreeRows.querySelectorAll('.table-row').forEach((el, i) => {
+    el.classList.toggle('selected', i === index);
+  });
+
+  updateDetails(filtered[index]);
+}
+
+// Keyboard navigation
+function setupKeyboardNavigation() {
+  document.addEventListener('keydown', (e) => {
+    // Modals take priority
+    if (!els.helpModal.classList.contains('hidden')) {
+      if (e.key === 'Escape' || e.key === '?') {
+        closeHelp();
+        e.preventDefault();
+      }
+      return;
+    }
+
+    if (!els.plansModal.classList.contains('hidden')) {
+      handlePlansKeys(e);
+      return;
+    }
+
+    // Global keys
+    switch (e.key) {
+      case '?':
+        openHelp();
+        e.preventDefault();
+        break;
+      case 'p':
+        openPlans();
+        e.preventDefault();
+        break;
+      case 'r':
+        refresh();
+        e.preventDefault();
+        break;
+      case 'o':
+        openPR();
+        e.preventDefault();
+        break;
+      case '0':
+        focusPanel('project-list');
+        e.preventDefault();
+        break;
+      case '1':
+        focusPanel('worktree-table');
+        e.preventDefault();
+        break;
+      case '2':
+        focusPanel('details-panel');
+        e.preventDefault();
+        break;
+      case 'h':
+      case 'ArrowLeft':
+        focusPanel('project-list');
+        e.preventDefault();
+        break;
+      case 'l':
+      case 'ArrowRight':
+        if (state.focusedPanel === 'project-list') {
+          focusPanel('worktree-table');
+        }
+        e.preventDefault();
+        break;
+      case 'j':
+      case 'ArrowDown':
+        navigateDown();
+        e.preventDefault();
+        break;
+      case 'k':
+      case 'ArrowUp':
+        navigateUp();
+        e.preventDefault();
+        break;
+      case 'Enter':
+        handleEnter();
+        e.preventDefault();
+        break;
+      case 'Tab':
+        if (e.shiftKey) {
+          focusPrevPanel();
+        } else {
+          focusNextPanel();
+        }
+        e.preventDefault();
+        break;
+    }
+  });
+}
+
+function handlePlansKeys(e) {
+  switch (e.key) {
+    case 'Escape':
+    case 'p':
+      closePlans();
+      e.preventDefault();
+      break;
+    case 'j':
+    case 'ArrowDown':
+      if (state.planIndex < state.plans.length - 1) {
+        state.planIndex++;
+        renderPlans();
+      }
+      e.preventDefault();
+      break;
+    case 'k':
+    case 'ArrowUp':
+      if (state.planIndex > 0) {
+        state.planIndex--;
+        renderPlans();
+      }
+      e.preventDefault();
+      break;
+    case 'o':
+      openIssue();
+      e.preventDefault();
+      break;
+  }
+}
+
+function focusPanel(panelId) {
+  state.focusedPanel = panelId;
+  document.getElementById(panelId)?.focus();
+}
+
+function focusNextPanel() {
+  const panels = ['project-list', 'worktree-table', 'details-panel'];
+  const idx = panels.indexOf(state.focusedPanel);
+  const next = panels[(idx + 1) % panels.length];
+  focusPanel(next);
+}
+
+function focusPrevPanel() {
+  const panels = ['project-list', 'worktree-table', 'details-panel'];
+  const idx = panels.indexOf(state.focusedPanel);
+  const prev = panels[(idx - 1 + panels.length) % panels.length];
+  focusPanel(prev);
+}
+
+function navigateDown() {
+  if (state.focusedPanel === 'project-list') {
+    if (state.projectIndex < state.projects.length - 1) {
+      state.projectIndex++;
+      selectProject(state.projects[state.projectIndex].name);
+    }
+  } else if (state.focusedPanel === 'worktree-table') {
+    const filtered = state.worktrees.filter(w => w.repo === state.selectedProject);
+    if (state.worktreeIndex < filtered.length - 1) {
+      selectWorktree(state.worktreeIndex + 1);
+    }
+  }
+}
+
+function navigateUp() {
+  if (state.focusedPanel === 'project-list') {
+    if (state.projectIndex > 0) {
+      state.projectIndex--;
+      selectProject(state.projects[state.projectIndex].name);
+    }
+  } else if (state.focusedPanel === 'worktree-table') {
+    if (state.worktreeIndex > 0) {
+      selectWorktree(state.worktreeIndex - 1);
+    }
+  }
+}
+
+function handleEnter() {
+  if (state.focusedPanel === 'project-list' && state.projects[state.projectIndex]) {
+    selectProject(state.projects[state.projectIndex].name);
+    focusPanel('worktree-table');
+  }
+}
+
+// Click handlers
+function setupClickHandlers() {
+  els.projectList.addEventListener('click', (e) => {
+    const item = e.target.closest('.list-item');
+    if (item) {
+      selectProject(item.dataset.project);
+      focusPanel('project-list');
+    }
+  });
+
+  els.worktreeRows.addEventListener('click', (e) => {
+    const row = e.target.closest('.table-row');
+    if (row) {
+      selectWorktree(parseInt(row.dataset.index));
+      focusPanel('worktree-table');
+    }
+  });
+
+  els.plansList.addEventListener('click', (e) => {
+    const item = e.target.closest('.list-item');
+    if (item) {
+      state.planIndex = parseInt(item.dataset.index);
+      renderPlans();
+    }
+  });
+
+  // Modal backdrop clicks
+  els.helpModal.addEventListener('click', (e) => {
+    if (e.target === els.helpModal) closeHelp();
+  });
+
+  els.plansModal.addEventListener('click', (e) => {
+    if (e.target === els.plansModal) closePlans();
+  });
+}
+
+// Modals
+function openHelp() {
+  els.helpModal.classList.remove('hidden');
+}
+
+function closeHelp() {
+  els.helpModal.classList.add('hidden');
+}
+
+function openPlans() {
+  loadPlans().then(() => {
+    els.plansModal.classList.remove('hidden');
+    els.plansList.focus();
+  });
+}
+
+function closePlans() {
+  els.plansModal.classList.add('hidden');
+}
+
+// Actions
+function openPR() {
+  if (!state.selectedWorktree || !state.selectedWorktree.prState) {
+    showNotification('No PR for this worktree');
+    return;
+  }
+
+  // Construct GitHub PR URL (assumes joshribakoff org)
+  const { repo, branch } = state.selectedWorktree;
+  const url = `https://github.com/joshribakoff/${repo}/pulls?q=head:${encodeURIComponent(branch)}`;
+  window.open(url, '_blank');
+}
+
+function openIssue() {
+  if (state.planIndex >= state.plans.length) return;
+
+  const plan = state.plans[state.planIndex];
+  if (!plan.issue) {
+    showNotification('No issue for this plan');
+    return;
+  }
+
+  const url = `https://github.com/joshribakoff/${plan.project}/issues/${plan.issue}`;
+  window.open(url, '_blank');
+}
+
+// Server-Sent Events
+function connectSSE() {
+  if (state.evtSource) {
+    state.evtSource.close();
+  }
+
+  setStatus('connecting');
+
+  state.evtSource = new EventSource(API_BASE + '/api/events');
+
+  state.evtSource.addEventListener('connected', () => {
+    setStatus('ok');
+  });
+
+  state.evtSource.addEventListener('update', (e) => {
+    try {
+      const data = JSON.parse(e.data);
+      if (data.type === 'health' || data.type === 'worktrees') {
+        refresh();
+      }
+    } catch (err) {
+      console.error('SSE parse error:', err);
+    }
+  });
+
+  state.evtSource.onerror = () => {
+    setStatus('error');
+    // Reconnect after delay
+    setTimeout(connectSSE, 5000);
+  };
+}
+
+function setStatus(status) {
+  els.statusIndicator.className = `status-${status}`;
+  els.statusIndicator.title = status === 'ok' ? 'Connected' :
+                              status === 'error' ? 'Disconnected' : 'Connecting...';
+}
+
+// Utilities
+function escapeHtml(str) {
+  if (!str) return '';
+  return str.replace(/[&<>"']/g, (c) => ({
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;',
+  }[c]));
+}
+
+function showNotification(msg) {
+  // Simple notification - could be enhanced
+  console.log('Notification:', msg);
+}
+
+function showError(msg) {
+  console.error('Error:', msg);
+  setStatus('error');
+}

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Bearing Dashboard</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header id="title-bar">
+    <span class="anchor-icon">&#x2693;</span> Bearing
+    <span id="status-indicator" class="status-ok" title="Connected"></span>
+  </header>
+
+  <main id="main-container">
+    <aside id="projects-panel" class="panel">
+      <div class="panel-header">[0] Projects</div>
+      <ul id="project-list" class="list" tabindex="0"></ul>
+    </aside>
+
+    <section id="worktrees-panel" class="panel">
+      <div class="panel-header">[1] Worktrees</div>
+      <div id="worktree-table" class="table" tabindex="0">
+        <div class="table-header">
+          <span class="col-folder">Folder</span>
+          <span class="col-branch">Branch</span>
+          <span class="col-status">Status</span>
+          <span class="col-pr">PR</span>
+        </div>
+        <div id="worktree-rows" class="table-body"></div>
+      </div>
+    </section>
+  </main>
+
+  <section id="details-section">
+    <div class="panel-header details-header">[2] Details</div>
+    <div id="details-panel" class="panel" tabindex="0">
+      <div id="details-content">Select a worktree to view details</div>
+    </div>
+  </section>
+
+  <footer id="footer-bar">
+    <span><kbd>0</kbd>-<kbd>2</kbd> panels</span>
+    <span><kbd>j/k</kbd> nav</span>
+    <span><kbd>n</kbd>ew</span>
+    <span><kbd>r</kbd>efresh</span>
+    <span><kbd>o</kbd>pen PR</span>
+    <span><kbd>p</kbd>lans</span>
+    <span><kbd>?</kbd> help</span>
+  </footer>
+
+  <!-- Help Modal -->
+  <div id="help-modal" class="modal hidden">
+    <div class="modal-content">
+      <h2>Bearing Dashboard - Keybindings</h2>
+      <div class="keybindings">
+        <h3>Navigation</h3>
+        <div class="binding"><kbd>0</kbd> Focus projects panel</div>
+        <div class="binding"><kbd>1</kbd> Focus worktrees panel</div>
+        <div class="binding"><kbd>2</kbd> Focus details panel</div>
+        <div class="binding"><kbd>h</kbd> / <kbd>←</kbd> Focus left panel</div>
+        <div class="binding"><kbd>l</kbd> / <kbd>→</kbd> Focus right panel</div>
+        <div class="binding"><kbd>j</kbd> / <kbd>↓</kbd> Move down</div>
+        <div class="binding"><kbd>k</kbd> / <kbd>↑</kbd> Move up</div>
+        <div class="binding"><kbd>Tab</kbd> Next panel</div>
+        <div class="binding"><kbd>Enter</kbd> Select item</div>
+
+        <h3>Actions</h3>
+        <div class="binding"><kbd>r</kbd> Refresh data</div>
+        <div class="binding"><kbd>o</kbd> Open PR in browser</div>
+        <div class="binding"><kbd>p</kbd> View plans</div>
+        <div class="binding"><kbd>?</kbd> Show this help</div>
+        <div class="binding"><kbd>Esc</kbd> Close modal</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Plans Modal -->
+  <div id="plans-modal" class="modal hidden">
+    <div class="modal-content modal-wide">
+      <h2>Plans <span class="modal-hint">(press o to open issue, Esc to close)</span></h2>
+      <div id="plans-list" class="list" tabindex="0"></div>
+    </div>
+  </div>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "bearing-web-dashboard",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "test": "playwright test",
+    "test:headed": "playwright test --headed",
+    "test:debug": "playwright test --debug",
+    "screenshot": "node scripts/generate_screenshots.js"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.40.0",
+    "playwright": "^1.40.0"
+  }
+}

--- a/web/playwright.config.js
+++ b/web/playwright.config.js
@@ -1,0 +1,28 @@
+// @ts-check
+const { defineConfig, devices } = require('@playwright/test');
+
+module.exports = defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    baseURL: 'http://localhost:8080',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'cd .. && go run ./cmd/bearing daemon start --foreground --port 8080',
+    url: 'http://localhost:8080',
+    reuseExistingServer: !process.env.CI,
+    timeout: 30000,
+  },
+});

--- a/web/scripts/generate_screenshots.js
+++ b/web/scripts/generate_screenshots.js
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+
+/**
+ * Screenshot generation script for the Bearing web dashboard.
+ * Captures screenshots for documentation, matching TUI screenshot scenarios.
+ */
+
+const { chromium } = require('playwright');
+const path = require('path');
+const fs = require('fs');
+
+const OUTPUT_DIR = path.join(__dirname, '../../docs/public/images');
+const BASE_URL = process.env.BASE_URL || 'http://localhost:8080';
+
+// Screenshot scenarios matching TUI
+const scenarios = [
+  {
+    name: 'web-dashboard-worktrees',
+    description: 'Worktrees view showing all worktrees',
+    setup: async (page) => {
+      await page.keyboard.press('w');
+    },
+  },
+  {
+    name: 'web-dashboard-projects',
+    description: 'Projects view showing project list',
+    setup: async (page) => {
+      await page.keyboard.press('p');
+    },
+  },
+  {
+    name: 'web-dashboard-plans',
+    description: 'Plans view showing all plans',
+    setup: async (page) => {
+      await page.keyboard.press('l');
+    },
+  },
+  {
+    name: 'web-dashboard-prs',
+    description: 'PRs view showing pull requests',
+    setup: async (page) => {
+      await page.keyboard.press('r');
+    },
+  },
+  {
+    name: 'web-dashboard-help',
+    description: 'Help modal showing keyboard shortcuts',
+    setup: async (page) => {
+      await page.keyboard.press('?');
+    },
+  },
+];
+
+async function generateScreenshots() {
+  console.log('Starting screenshot generation...');
+  console.log(`Output directory: ${OUTPUT_DIR}`);
+  console.log(`Base URL: ${BASE_URL}`);
+
+  // Ensure output directory exists
+  if (!fs.existsSync(OUTPUT_DIR)) {
+    fs.mkdirSync(OUTPUT_DIR, { recursive: true });
+  }
+
+  const browser = await chromium.launch();
+  const context = await browser.newContext({
+    viewport: { width: 1280, height: 720 },
+    deviceScaleFactor: 2, // Retina
+  });
+  const page = await context.newPage();
+
+  try {
+    // Navigate to dashboard
+    console.log('Loading dashboard...');
+    await page.goto(BASE_URL);
+    await page.waitForLoadState('networkidle');
+
+    for (const scenario of scenarios) {
+      console.log(`Capturing: ${scenario.name}`);
+
+      // Reset to default state
+      await page.goto(BASE_URL);
+      await page.waitForLoadState('networkidle');
+      await page.waitForTimeout(500);
+
+      // Run setup function
+      if (scenario.setup) {
+        await scenario.setup(page);
+        await page.waitForTimeout(300);
+      }
+
+      // Capture screenshot
+      const filename = `${scenario.name}.png`;
+      const filepath = path.join(OUTPUT_DIR, filename);
+
+      await page.screenshot({
+        path: filepath,
+        fullPage: false,
+      });
+
+      console.log(`  Saved: ${filename}`);
+    }
+
+    console.log('\nAll screenshots generated successfully!');
+    console.log(`Files saved to: ${OUTPUT_DIR}`);
+
+  } catch (error) {
+    console.error('Error generating screenshots:', error);
+    process.exit(1);
+  } finally {
+    await browser.close();
+  }
+}
+
+// Check if server is available
+async function checkServer() {
+  const { chromium } = require('playwright');
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+
+  try {
+    const response = await page.goto(BASE_URL, { timeout: 5000 });
+    await browser.close();
+    return response && response.ok();
+  } catch {
+    await browser.close();
+    return false;
+  }
+}
+
+async function main() {
+  console.log('Bearing Web Dashboard Screenshot Generator\n');
+
+  // Check if server is running
+  console.log('Checking if server is running...');
+  const serverAvailable = await checkServer();
+
+  if (!serverAvailable) {
+    console.error(`Error: Server not available at ${BASE_URL}`);
+    console.error('Please start the daemon with: go run ./cmd/bearing daemon start --port 8080');
+    process.exit(1);
+  }
+
+  console.log('Server is available.\n');
+  await generateScreenshots();
+}
+
+main();

--- a/web/style.css
+++ b/web/style.css
@@ -1,0 +1,391 @@
+/* Bearing Web Dashboard - Darcula-inspired theme matching TUI */
+
+:root {
+  /* Darcula palette */
+  --bg: #1e1e1e;
+  --bg-panel: #252526;
+  --bg-surface: #2d2d2d;
+  --bg-highlight: #37373d;
+  --bg-selection: #264f78;
+  --bg-selection-focus: #2d5a8a;
+
+  --border: #3c3c3c;
+  --border-focus: #007acc;
+  --border-dim: #2d2d2d;
+
+  --text: #d4d4d4;
+  --text-dim: #808080;
+  --text-bright: #ffffff;
+
+  --accent-orange: #ce9178;
+  --accent-yellow: #dcdcaa;
+  --accent-green: #6a9955;
+  --accent-blue: #569cd6;
+  --accent-purple: #c586c0;
+  --accent-cyan: #4ec9b0;
+  --accent-red: #f44747;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'SF Mono', 'Menlo', 'Monaco', 'Consolas', monospace;
+  font-size: 13px;
+  background: var(--bg);
+  color: var(--text);
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+/* Title Bar */
+#title-bar {
+  background: var(--bg-surface);
+  color: var(--accent-cyan);
+  font-weight: bold;
+  text-align: center;
+  padding: 4px 8px;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
+}
+
+.anchor-icon {
+  font-size: 16px;
+}
+
+#status-indicator {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  margin-left: 8px;
+}
+
+.status-ok { background: var(--accent-green); }
+.status-error { background: var(--accent-red); }
+.status-connecting { background: var(--accent-yellow); }
+
+/* Main Container */
+#main-container {
+  display: flex;
+  flex: 1;
+  overflow: hidden;
+  padding: 8px;
+  gap: 8px;
+}
+
+/* Panels */
+.panel {
+  background: var(--bg-panel);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.panel:focus-within {
+  border-color: var(--border-focus);
+}
+
+.panel-header {
+  background: var(--bg-surface);
+  color: var(--accent-yellow);
+  font-weight: bold;
+  padding: 4px 8px;
+  border-bottom: 1px solid var(--border);
+}
+
+/* Projects Panel */
+#projects-panel {
+  width: 220px;
+  min-width: 180px;
+  flex-shrink: 0;
+}
+
+/* Worktrees Panel */
+#worktrees-panel {
+  flex: 1;
+}
+
+/* Lists */
+.list {
+  list-style: none;
+  overflow-y: auto;
+  flex: 1;
+  outline: none;
+}
+
+.list-item {
+  padding: 4px 8px;
+  cursor: pointer;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.list-item:hover {
+  background: var(--bg-highlight);
+}
+
+.list-item.selected {
+  background: var(--bg-selection);
+  color: var(--text-bright);
+}
+
+.list:focus .list-item.selected {
+  background: var(--bg-selection-focus);
+  font-weight: bold;
+}
+
+.project-count {
+  color: var(--text-dim);
+  font-size: 11px;
+}
+
+/* Table */
+.table {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  overflow: hidden;
+  outline: none;
+}
+
+.table-header {
+  display: flex;
+  background: var(--bg-surface);
+  color: var(--accent-blue);
+  font-weight: bold;
+  padding: 4px 8px;
+  border-bottom: 1px solid var(--border);
+}
+
+.table-body {
+  flex: 1;
+  overflow-y: auto;
+}
+
+.table-row {
+  display: flex;
+  padding: 4px 8px;
+  cursor: pointer;
+}
+
+.table-row:nth-child(odd) {
+  background: var(--bg-surface);
+}
+
+.table-row:nth-child(even) {
+  background: var(--bg-panel);
+}
+
+.table-row:hover {
+  background: var(--bg-highlight);
+}
+
+.table-row.selected {
+  background: var(--bg-selection);
+  color: var(--text-bright);
+}
+
+.table:focus .table-row.selected {
+  background: var(--bg-selection-focus);
+  font-weight: bold;
+}
+
+/* Table columns */
+.col-folder { flex: 2; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.col-branch { flex: 1.5; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.col-status { flex: 1; text-align: center; }
+.col-pr { flex: 0.8; text-align: center; }
+
+/* Status indicators */
+.status-dirty { color: var(--accent-yellow); }
+.status-clean { color: var(--accent-green); }
+.status-unpushed { color: var(--accent-orange); }
+
+.pr-open { color: var(--accent-green); }
+.pr-merged { color: var(--accent-purple); }
+.pr-draft { color: var(--text-dim); }
+.pr-closed { color: var(--accent-red); }
+
+.base-indicator { color: var(--accent-blue); font-size: 10px; margin-left: 4px; }
+
+/* Details Section */
+#details-section {
+  padding: 0 8px 8px;
+}
+
+.details-header {
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-bottom: none;
+  border-radius: 4px 4px 0 0;
+}
+
+#details-panel {
+  min-height: 100px;
+  max-height: 150px;
+  padding: 8px;
+  border-radius: 0 0 4px 4px;
+  outline: none;
+}
+
+#details-content {
+  color: var(--text-dim);
+}
+
+.detail-row {
+  display: flex;
+  margin-bottom: 4px;
+}
+
+.detail-label {
+  color: var(--accent-yellow);
+  width: 100px;
+  flex-shrink: 0;
+}
+
+.detail-value {
+  color: var(--text);
+}
+
+/* Footer */
+#footer-bar {
+  background: var(--bg-surface);
+  color: var(--text-dim);
+  padding: 4px 8px;
+  border-top: 1px solid var(--border);
+  display: flex;
+  gap: 16px;
+  font-size: 12px;
+}
+
+kbd {
+  color: var(--accent-yellow);
+  font-family: inherit;
+}
+
+/* Modals */
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+
+.modal.hidden {
+  display: none;
+}
+
+.modal-content {
+  background: var(--bg-panel);
+  border: 1px solid var(--accent-cyan);
+  border-radius: 4px;
+  padding: 16px;
+  max-width: 500px;
+  max-height: 80vh;
+  overflow-y: auto;
+}
+
+.modal-wide {
+  max-width: 700px;
+  width: 90%;
+}
+
+.modal-content h2 {
+  color: var(--accent-cyan);
+  margin-bottom: 16px;
+  font-size: 16px;
+}
+
+.modal-hint {
+  color: var(--text-dim);
+  font-size: 12px;
+  font-weight: normal;
+}
+
+.keybindings h3 {
+  color: var(--text);
+  margin: 12px 0 8px;
+  font-size: 13px;
+}
+
+.binding {
+  padding: 2px 0;
+  color: var(--text-dim);
+}
+
+.binding kbd {
+  display: inline-block;
+  min-width: 20px;
+  text-align: center;
+}
+
+/* Plans list in modal */
+#plans-list .list-item {
+  display: grid;
+  grid-template-columns: 20px 1fr 100px 80px;
+  gap: 8px;
+  align-items: center;
+}
+
+.plan-status {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+}
+
+.plan-status.active { background: var(--accent-green); }
+.plan-status.in_progress { background: var(--accent-yellow); }
+.plan-status.draft { background: var(--text-dim); }
+.plan-status.completed { background: var(--accent-blue); }
+
+.plan-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.plan-project {
+  color: var(--text-dim);
+  font-size: 11px;
+}
+
+.plan-issue {
+  color: var(--accent-cyan);
+  font-size: 11px;
+}
+
+/* Scrollbar styling */
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+::-webkit-scrollbar-track {
+  background: var(--bg-surface);
+}
+
+::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 4px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: var(--text-dim);
+}

--- a/web/tests/dashboard.spec.js
+++ b/web/tests/dashboard.spec.js
@@ -1,0 +1,173 @@
+// @ts-check
+const { test, expect } = require('@playwright/test');
+
+test.describe('Dashboard', () => {
+  test('page loads and renders header', async ({ page }) => {
+    await page.goto('/');
+
+    // Check page title
+    await expect(page).toHaveTitle(/Bearing/);
+
+    // Check header is present
+    const header = page.locator('header, .header, h1').first();
+    await expect(header).toBeVisible();
+  });
+
+  test('displays worktrees view by default', async ({ page }) => {
+    await page.goto('/');
+
+    // Wait for data to load
+    await page.waitForLoadState('networkidle');
+
+    // Check that worktrees section exists
+    const worktreesSection = page.locator('[data-view="worktrees"], .worktrees, .view-worktrees').first();
+    await expect(worktreesSection).toBeVisible({ timeout: 5000 });
+  });
+
+  test('renders project list', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    // Check for project items or empty state
+    const projects = page.locator('[data-project], .project-item, .project');
+    const count = await projects.count();
+
+    // Either has projects or shows empty state
+    if (count === 0) {
+      const emptyState = page.locator('.empty-state, .no-data');
+      await expect(emptyState).toBeVisible();
+    } else {
+      await expect(projects.first()).toBeVisible();
+    }
+  });
+});
+
+test.describe('Keyboard Navigation', () => {
+  test('w key switches to worktrees view', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    // Press 'w' key
+    await page.keyboard.press('w');
+
+    // Check worktrees view is active
+    const worktreesView = page.locator('[data-view="worktrees"].active, .view-worktrees.active, .worktrees-view');
+    await expect(worktreesView).toBeVisible({ timeout: 2000 });
+  });
+
+  test('p key switches to projects view', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    // Press 'p' key
+    await page.keyboard.press('p');
+
+    // Check projects view is active
+    const projectsView = page.locator('[data-view="projects"].active, .view-projects.active, .projects-view');
+    await expect(projectsView).toBeVisible({ timeout: 2000 });
+  });
+
+  test('j/k keys navigate list items', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    // Navigate down with 'j'
+    await page.keyboard.press('j');
+
+    // Check if selection moved (look for selected/focused class)
+    const selectedItem = page.locator('.selected, .focused, [aria-selected="true"]').first();
+    // May not have items if empty
+    const count = await selectedItem.count();
+    if (count > 0) {
+      await expect(selectedItem).toBeVisible();
+    }
+  });
+
+  test('? key shows help modal', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    // Press '?' key
+    await page.keyboard.press('?');
+
+    // Check help modal appears
+    const helpModal = page.locator('.modal, .help-modal, [role="dialog"]');
+    await expect(helpModal).toBeVisible({ timeout: 2000 });
+  });
+
+  test('Escape closes modal', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    // Open help modal
+    await page.keyboard.press('?');
+
+    // Wait for modal
+    const helpModal = page.locator('.modal, .help-modal, [role="dialog"]');
+    await expect(helpModal).toBeVisible({ timeout: 2000 });
+
+    // Close with Escape
+    await page.keyboard.press('Escape');
+
+    // Modal should be hidden
+    await expect(helpModal).toBeHidden({ timeout: 2000 });
+  });
+});
+
+test.describe('View Switching', () => {
+  test('can switch between all views', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    const views = ['w', 'p', 'l', 'r'];
+
+    for (const key of views) {
+      await page.keyboard.press(key);
+      // Small delay to let view switch
+      await page.waitForTimeout(100);
+    }
+
+    // Back to worktrees
+    await page.keyboard.press('w');
+    const worktreesView = page.locator('[data-view="worktrees"], .worktrees-view, .view-worktrees');
+    await expect(worktreesView.first()).toBeVisible({ timeout: 2000 });
+  });
+});
+
+test.describe('API Integration', () => {
+  test('fetches worktrees from API', async ({ page }) => {
+    // Intercept API call
+    const responsePromise = page.waitForResponse('**/api/worktrees**');
+
+    await page.goto('/');
+
+    const response = await responsePromise;
+    expect(response.status()).toBe(200);
+
+    const data = await response.json();
+    expect(Array.isArray(data)).toBe(true);
+  });
+
+  test('fetches projects from API', async ({ page }) => {
+    const responsePromise = page.waitForResponse('**/api/projects**');
+
+    await page.goto('/');
+    await page.keyboard.press('p'); // Switch to projects view
+
+    const response = await responsePromise;
+    expect(response.status()).toBe(200);
+
+    const data = await response.json();
+    expect(Array.isArray(data)).toBe(true);
+  });
+
+  test('status endpoint returns running', async ({ page }) => {
+    await page.goto('/');
+
+    const response = await page.request.get('/api/status');
+    expect(response.status()).toBe(200);
+
+    const data = await response.json();
+    expect(data.running).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Add HTTP API server integrated into daemon (port 8374)
- Endpoints: `/api/projects`, `/api/worktrees`, `/api/plans`, `/api/prs`, `/api/health`, `/api/status`, `/api/events` (SSE)
- Vanilla JS frontend matching TUI layout (three-panel design)
- Keyboard navigation (0-2 panels, j/k nav, ? help, p plans)
- Real-time updates via Server-Sent Events
- Darcula-inspired dark theme

## Testing
- 12 unit tests for HTTP endpoints
- Integration tests with realistic JSONL data
- Playwright E2E tests for UI
- Screenshot generation script

## Test plan
- [x] Go tests pass
- [ ] Playwright E2E tests
- [ ] Manual testing of keyboard navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)