### PR TITLE
Add GitHub-like tab navigation and issues API

### DIFF
--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -1,0 +1,80 @@
+# Bearing Keybindings
+
+Standard keybindings for TUI and Web dashboard.
+
+## Navigation
+
+| Key | Action | TUI | Web |
+|-----|--------|-----|-----|
+| j / Down | Move down | Yes | Yes |
+| k / Up | Move up | Yes | Yes |
+| h / Left | Focus left panel / projects | Yes | Yes |
+| l / Right | Focus right panel / worktrees | Yes | Yes |
+| Tab | Next panel | Yes | Yes (cycles views) |
+| Shift+Tab | Previous panel | Yes | No |
+| Enter | Select item | Yes | Yes |
+| 0 | Focus projects panel | Yes | No |
+| 1 | Focus worktrees panel | Yes | Switch to worktrees view |
+| 2 | Focus details panel | Yes | Switch to issues view |
+| 3 | - | No | Switch to PRs view |
+
+## Actions
+
+| Key | Action | TUI | Web |
+|-----|--------|-----|-----|
+| r | Refresh data | Yes | Yes |
+| R | Force refresh (daemon) | Yes | No |
+| o | Open PR in browser | Yes | Yes |
+| p | View plans modal | Yes | Yes |
+| n | New worktree | Yes (placeholder) | No |
+| c | Cleanup worktree | Yes (placeholder) | No |
+| d | Daemon health check | Yes | No |
+| x | Toggle closed PRs | Yes | No |
+| q | Quit | Yes | No (browser) |
+| Ctrl+C | Quit | Yes | No (browser) |
+
+## Modals
+
+| Key | Action | TUI | Web |
+|-----|--------|-----|-----|
+| ? | Open/close help | Yes | Yes (open only) |
+| Escape | Close modal | Yes | Yes |
+| p | Close plans modal (when open) | Yes | Yes |
+
+### Plans Modal Navigation
+
+| Key | Action | TUI | Web |
+|-----|--------|-----|-----|
+| j / Down | Move down | Yes | Yes |
+| k / Up | Move up | Yes | Yes |
+| o | Open issue in browser | Yes | Yes |
+| Escape | Close | Yes | Yes |
+| p | Close | Yes | Yes |
+
+## Discrepancies
+
+### TUI-only features
+- **Number keys (0/1/2)**: TUI uses these for direct panel focus; Web uses 1/2/3 for view switching
+- **Shift+Tab**: TUI supports reverse panel cycling; Web does not
+- **R (uppercase)**: Force refresh via daemon
+- **n/c**: Worktree creation and cleanup (placeholders)
+- **d**: Daemon health check
+- **x**: Toggle visibility of closed/merged PRs
+- **q/Ctrl+C**: App quit (not applicable in browser)
+
+### Web-only features
+- **Tab**: Cycles through views (worktrees/issues/prs) rather than panels
+- **View switching (1/2/3)**: Switches between worktrees, issues, and PRs views
+
+### Behavioral differences
+- **h/l**: In TUI, these focus specific panels. In Web, `h` always goes to project list, `l` moves from project list to worktree table only.
+- **Help modal close**: TUI supports `?` to toggle help; Web only supports `Escape` or `?` to close.
+
+## Recommended Alignment
+
+To achieve consistency, consider:
+
+1. **Web should add Shift+Tab** for reverse panel navigation
+2. **TUI should add view switching** when issues/PRs views are implemented
+3. **Standardize number keys**: Either both use 0/1/2 for panels or both use 1/2/3 for views
+4. **Web should add x key** for toggle closed PRs when filtering is implemented

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -1,12 +1,630 @@
 ---
-import { getEntry } from 'astro:content';
-import DocsLayout from '../layouts/DocsLayout.astro';
-
-const entry = await getEntry('docs', 'index');
-if (!entry) throw new Error('Index page not found');
-const { Content } = await entry.render();
+import { initScript } from 'sailkit/packages/lantern';
+import ThemeToggle from 'sailkit/packages/lantern/ThemeToggle.astro';
 ---
 
-<DocsLayout title={entry.data.title} slug="index">
-  <Content />
-</DocsLayout>
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Bearing - One conversation. Full control.</title>
+    <meta name="description" content="Manage parallel AI workstreams without the chaos. Git worktree management for Claude Code." />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <script is:inline set:html={initScript} />
+    <style>
+      :root {
+        --color-bg: #0a0e17;
+        --color-bg-elevated: #111827;
+        --color-text: #e2e8f0;
+        --color-text-muted: #64748b;
+        --color-accent: #3b82f6;
+        --color-accent-glow: rgba(59, 130, 246, 0.4);
+        --color-border: rgba(255, 255, 255, 0.08);
+        --font-mono: 'IBM Plex Mono', ui-monospace, monospace;
+        --font-sans: 'IBM Plex Sans', system-ui, sans-serif;
+      }
+
+      [data-theme="light"] {
+        --color-bg: #f8fafc;
+        --color-bg-elevated: #ffffff;
+        --color-text: #1e293b;
+        --color-text-muted: #64748b;
+        --color-accent: #2563eb;
+        --color-accent-glow: rgba(37, 99, 235, 0.2);
+        --color-border: rgba(0, 0, 0, 0.08);
+      }
+
+      * { margin: 0; padding: 0; box-sizing: border-box; }
+
+      html {
+        font-family: var(--font-sans);
+        background: var(--color-bg);
+        color: var(--color-text);
+        scroll-behavior: smooth;
+      }
+
+      body {
+        min-height: 100vh;
+        overflow-x: hidden;
+      }
+
+      /* Animated background grid */
+      .bg-grid {
+        position: fixed;
+        inset: 0;
+        background-image:
+          linear-gradient(rgba(59, 130, 246, 0.03) 1px, transparent 1px),
+          linear-gradient(90deg, rgba(59, 130, 246, 0.03) 1px, transparent 1px);
+        background-size: 60px 60px;
+        pointer-events: none;
+        z-index: 0;
+      }
+
+      [data-theme="light"] .bg-grid {
+        background-image:
+          linear-gradient(rgba(37, 99, 235, 0.05) 1px, transparent 1px),
+          linear-gradient(90deg, rgba(37, 99, 235, 0.05) 1px, transparent 1px);
+      }
+
+      /* Radial glow behind hero */
+      .bg-glow {
+        position: fixed;
+        top: -20%;
+        left: 50%;
+        transform: translateX(-50%);
+        width: 140%;
+        height: 80%;
+        background: radial-gradient(ellipse at center, var(--color-accent-glow) 0%, transparent 60%);
+        pointer-events: none;
+        z-index: 0;
+        opacity: 0.6;
+      }
+
+      /* Navigation */
+      nav {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        z-index: 100;
+        padding: 1rem 2rem;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        background: linear-gradient(to bottom, var(--color-bg), transparent);
+        backdrop-filter: blur(8px);
+      }
+
+      .nav-logo {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        font-family: var(--font-mono);
+        font-weight: 600;
+        font-size: 1.25rem;
+        color: var(--color-text);
+        text-decoration: none;
+      }
+
+      .nav-logo span {
+        font-size: 1.75rem;
+      }
+
+      .nav-links {
+        display: flex;
+        align-items: center;
+        gap: 2rem;
+      }
+
+      .nav-links a {
+        font-family: var(--font-mono);
+        font-size: 0.875rem;
+        color: var(--color-text-muted);
+        text-decoration: none;
+        transition: color 0.2s;
+      }
+
+      .nav-links a:hover {
+        color: var(--color-accent);
+      }
+
+      /* Hero Section */
+      .hero {
+        position: relative;
+        z-index: 1;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        padding: 8rem 2rem 4rem;
+        text-align: center;
+      }
+
+      .hero-badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.5rem 1rem;
+        background: var(--color-bg-elevated);
+        border: 1px solid var(--color-border);
+        border-radius: 100px;
+        font-family: var(--font-mono);
+        font-size: 0.75rem;
+        color: var(--color-text-muted);
+        margin-bottom: 2rem;
+        animation: fadeInUp 0.6s ease-out;
+      }
+
+      .hero-badge::before {
+        content: '';
+        width: 6px;
+        height: 6px;
+        background: #22c55e;
+        border-radius: 50%;
+        animation: pulse 2s infinite;
+      }
+
+      @keyframes pulse {
+        0%, 100% { opacity: 1; }
+        50% { opacity: 0.5; }
+      }
+
+      .hero h1 {
+        font-family: var(--font-mono);
+        font-size: clamp(2.5rem, 6vw, 4.5rem);
+        font-weight: 700;
+        line-height: 1.1;
+        margin-bottom: 1.5rem;
+        animation: fadeInUp 0.6s ease-out 0.1s both;
+      }
+
+      .hero h1 .accent {
+        color: var(--color-accent);
+      }
+
+      .hero-subtitle {
+        font-size: clamp(1rem, 2vw, 1.25rem);
+        color: var(--color-text-muted);
+        max-width: 540px;
+        margin-bottom: 2.5rem;
+        line-height: 1.6;
+        animation: fadeInUp 0.6s ease-out 0.2s both;
+      }
+
+      .hero-buttons {
+        display: flex;
+        gap: 1rem;
+        flex-wrap: wrap;
+        justify-content: center;
+        animation: fadeInUp 0.6s ease-out 0.3s both;
+      }
+
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.875rem 1.75rem;
+        font-family: var(--font-mono);
+        font-size: 0.875rem;
+        font-weight: 500;
+        text-decoration: none;
+        border-radius: 8px;
+        transition: all 0.2s;
+      }
+
+      .btn-primary {
+        background: var(--color-accent);
+        color: #fff;
+        border: none;
+        box-shadow: 0 0 20px var(--color-accent-glow);
+      }
+
+      .btn-primary:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 0 30px var(--color-accent-glow), 0 10px 30px -10px var(--color-accent-glow);
+      }
+
+      .btn-secondary {
+        background: transparent;
+        color: var(--color-text);
+        border: 1px solid var(--color-border);
+      }
+
+      .btn-secondary:hover {
+        border-color: var(--color-text-muted);
+        background: var(--color-bg-elevated);
+      }
+
+      /* TUI Screenshot */
+      .tui-container {
+        position: relative;
+        margin-top: 4rem;
+        animation: fadeInUp 0.8s ease-out 0.4s both;
+      }
+
+      .tui-window {
+        position: relative;
+        background: #1e1e2e;
+        border-radius: 12px;
+        overflow: hidden;
+        box-shadow:
+          0 0 0 1px rgba(255, 255, 255, 0.1),
+          0 25px 50px -12px rgba(0, 0, 0, 0.5),
+          0 0 100px var(--color-accent-glow);
+        max-width: 1000px;
+        margin: 0 auto;
+      }
+
+      .tui-titlebar {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 12px 16px;
+        background: #16161e;
+        border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+      }
+
+      .tui-dot {
+        width: 12px;
+        height: 12px;
+        border-radius: 50%;
+      }
+
+      .tui-dot.red { background: #ff5f56; }
+      .tui-dot.yellow { background: #ffbd2e; }
+      .tui-dot.green { background: #27c93f; }
+
+      .tui-title {
+        flex: 1;
+        text-align: center;
+        font-family: var(--font-mono);
+        font-size: 0.75rem;
+        color: #64748b;
+        margin-right: 52px;
+      }
+
+      .tui-window img {
+        display: block;
+        width: 100%;
+        height: auto;
+      }
+
+      /* Scan line effect */
+      .tui-scanlines {
+        position: absolute;
+        inset: 0;
+        background: repeating-linear-gradient(
+          0deg,
+          transparent,
+          transparent 2px,
+          rgba(0, 0, 0, 0.03) 2px,
+          rgba(0, 0, 0, 0.03) 4px
+        );
+        pointer-events: none;
+        border-radius: 12px;
+      }
+
+      @keyframes fadeInUp {
+        from {
+          opacity: 0;
+          transform: translateY(20px);
+        }
+        to {
+          opacity: 1;
+          transform: translateY(0);
+        }
+      }
+
+      /* Benefits Section */
+      .benefits {
+        position: relative;
+        z-index: 1;
+        padding: 8rem 2rem;
+      }
+
+      .section-header {
+        text-align: center;
+        margin-bottom: 4rem;
+      }
+
+      .section-header h2 {
+        font-family: var(--font-mono);
+        font-size: clamp(1.75rem, 4vw, 2.5rem);
+        font-weight: 600;
+        margin-bottom: 1rem;
+      }
+
+      .section-header p {
+        color: var(--color-text-muted);
+        max-width: 480px;
+        margin: 0 auto;
+      }
+
+      .benefits-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+        gap: 1.5rem;
+        max-width: 1200px;
+        margin: 0 auto;
+      }
+
+      .benefit-card {
+        background: var(--color-bg-elevated);
+        border: 1px solid var(--color-border);
+        border-radius: 12px;
+        padding: 2rem;
+        transition: all 0.3s;
+      }
+
+      .benefit-card:hover {
+        border-color: var(--color-accent);
+        transform: translateY(-4px);
+        box-shadow: 0 20px 40px -20px var(--color-accent-glow);
+      }
+
+      .benefit-icon {
+        width: 48px;
+        height: 48px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: linear-gradient(135deg, var(--color-accent), #8b5cf6);
+        border-radius: 10px;
+        margin-bottom: 1.5rem;
+        font-size: 1.5rem;
+      }
+
+      .benefit-card h3 {
+        font-family: var(--font-mono);
+        font-size: 1.125rem;
+        font-weight: 600;
+        margin-bottom: 0.75rem;
+      }
+
+      .benefit-card p {
+        color: var(--color-text-muted);
+        font-size: 0.9375rem;
+        line-height: 1.6;
+      }
+
+      /* Features Section */
+      .features {
+        position: relative;
+        z-index: 1;
+        padding: 4rem 2rem 8rem;
+      }
+
+      .features-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+        gap: 1rem;
+        max-width: 900px;
+        margin: 0 auto;
+      }
+
+      .feature-item {
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+        padding: 1rem 1.25rem;
+        background: var(--color-bg-elevated);
+        border: 1px solid var(--color-border);
+        border-radius: 8px;
+        font-family: var(--font-mono);
+        font-size: 0.875rem;
+        transition: border-color 0.2s;
+      }
+
+      .feature-item:hover {
+        border-color: var(--color-accent);
+      }
+
+      .feature-item::before {
+        content: '✓';
+        color: var(--color-accent);
+        font-weight: 600;
+      }
+
+      /* CTA Section */
+      .cta {
+        position: relative;
+        z-index: 1;
+        padding: 6rem 2rem;
+        text-align: center;
+        background: var(--color-bg-elevated);
+        border-top: 1px solid var(--color-border);
+      }
+
+      .cta h2 {
+        font-family: var(--font-mono);
+        font-size: clamp(1.5rem, 3vw, 2rem);
+        margin-bottom: 1rem;
+      }
+
+      .cta p {
+        color: var(--color-text-muted);
+        margin-bottom: 2rem;
+      }
+
+      .cta-code {
+        display: inline-block;
+        background: var(--color-bg);
+        border: 1px solid var(--color-border);
+        border-radius: 8px;
+        padding: 1rem 1.5rem;
+        font-family: var(--font-mono);
+        font-size: 0.875rem;
+        color: var(--color-accent);
+        margin-bottom: 2rem;
+      }
+
+      /* Footer */
+      footer {
+        position: relative;
+        z-index: 1;
+        padding: 2rem;
+        text-align: center;
+        border-top: 1px solid var(--color-border);
+      }
+
+      footer p {
+        font-family: var(--font-mono);
+        font-size: 0.75rem;
+        color: var(--color-text-muted);
+      }
+
+      footer a {
+        color: var(--color-accent);
+        text-decoration: none;
+      }
+
+      footer a:hover {
+        text-decoration: underline;
+      }
+
+      /* Mobile */
+      @media (max-width: 640px) {
+        nav {
+          padding: 1rem;
+        }
+
+        .nav-links {
+          gap: 1rem;
+        }
+
+        .hero {
+          padding: 6rem 1rem 2rem;
+        }
+
+        .tui-container {
+          margin: 2rem -1rem 0;
+        }
+
+        .tui-window {
+          border-radius: 0;
+        }
+
+        .benefits, .features {
+          padding: 4rem 1rem;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="bg-grid"></div>
+    <div class="bg-glow"></div>
+
+    <nav>
+      <a href="/" class="nav-logo">
+        <span>⚓</span>
+        Bearing
+      </a>
+      <div class="nav-links">
+        <a href="/docs/">Docs</a>
+        <a href="https://github.com/joshribakoff/bearing" target="_blank" rel="noopener">GitHub</a>
+        <ThemeToggle />
+      </div>
+    </nav>
+
+    <section class="hero">
+      <div class="hero-badge">Works with Claude Code</div>
+      <h1>One conversation.<br/><span class="accent">Full control.</span></h1>
+      <p class="hero-subtitle">
+        Manage parallel AI workstreams without the chaos.
+        Worktree isolation. File-based state. You're the orchestrator.
+      </p>
+      <div class="hero-buttons">
+        <a href="/docs/" class="btn btn-primary">
+          Get Started
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M5 12h14m-7-7l7 7-7 7"/>
+          </svg>
+        </a>
+        <a href="https://github.com/joshribakoff/bearing" class="btn btn-secondary" target="_blank" rel="noopener">
+          View on GitHub
+        </a>
+      </div>
+
+      <div class="tui-container">
+        <div class="tui-window">
+          <div class="tui-titlebar">
+            <div class="tui-dot red"></div>
+            <div class="tui-dot yellow"></div>
+            <div class="tui-dot green"></div>
+            <div class="tui-title">bearing-tui</div>
+          </div>
+          <img src="/images/tui-screenshot.svg" alt="Bearing Terminal UI showing project list, worktrees, and details panel" />
+          <div class="tui-scanlines"></div>
+        </div>
+      </div>
+    </section>
+
+    <section class="benefits">
+      <div class="section-header">
+        <h2>Why Bearing?</h2>
+        <p>Parallelism without the pain. AI assistance without the chaos.</p>
+      </div>
+      <div class="benefits-grid">
+        <div class="benefit-card">
+          <div class="benefit-icon">🔀</div>
+          <h3>No Contention</h3>
+          <p>Background agents work in isolated git worktrees. No merge conflicts in real-time. Integrate when you're ready.</p>
+        </div>
+        <div class="benefit-card">
+          <div class="benefit-icon">📁</div>
+          <h3>No Context Bloat</h3>
+          <p>State lives in JSONL files, not your conversation. Keep your context clean. Query state with simple tools.</p>
+        </div>
+        <div class="benefit-card">
+          <div class="benefit-icon">👁️</div>
+          <h3>Full Visibility</h3>
+          <p>See all active work in one TUI. PR status, health checks, dirty files. Everything at a glance.</p>
+        </div>
+        <div class="benefit-card">
+          <div class="benefit-icon">🎮</div>
+          <h3>You're In Control</h3>
+          <p>Parallelism is opt-in. You decide when to spawn agents, what to background. No runaway swarms.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="features">
+      <div class="section-header">
+        <h2>Built for developers</h2>
+      </div>
+      <div class="features-grid">
+        <div class="feature-item">Vim-style keybindings</div>
+        <div class="feature-item">PR status monitoring</div>
+        <div class="feature-item">JSONL state files</div>
+        <div class="feature-item">Health checks</div>
+        <div class="feature-item">Session persistence</div>
+        <div class="feature-item">Plan tracking</div>
+        <div class="feature-item">Claude Code ready</div>
+        <div class="feature-item">No databases</div>
+      </div>
+    </section>
+
+    <section class="cta">
+      <h2>Ready to try it?</h2>
+      <p>Clone, install, and start vibing with Claude.</p>
+      <div class="cta-code">
+        git clone https://github.com/joshribakoff/bearing && ./install.sh
+      </div>
+      <div>
+        <a href="/docs/" class="btn btn-primary">Read the Docs</a>
+      </div>
+    </section>
+
+    <footer>
+      <p>
+        Built by <a href="https://joshribakoff.com" target="_blank" rel="noopener">Josh Ribakoff</a> •
+        <a href="https://github.com/joshribakoff/bearing" target="_blank" rel="noopener">GitHub</a> •
+        <a href="/docs/">Documentation</a>
+      </p>
+    </footer>
+  </body>
+</html>

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -2,6 +2,8 @@ package daemon
 
 import (
 	"fmt"
+	"io/fs"
+	"net/http"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -14,17 +16,22 @@ import (
 	"github.com/joshribakoff/bearing/internal/jsonl"
 )
 
+// HTTPPort is the port the HTTP server listens on
+const HTTPPort = 8374
+
 // Config holds daemon configuration
 type Config struct {
 	WorkspaceDir string
 	BearingDir   string
 	Interval     time.Duration
+	StaticFS     fs.FS // Optional: embedded static files for web dashboard
 }
 
 // Daemon manages the health monitoring background process
 type Daemon struct {
-	config Config
-	stop   chan struct{}
+	config     Config
+	stop       chan struct{}
+	httpServer *HTTPServer
 }
 
 // New creates a new daemon instance
@@ -133,6 +140,18 @@ func (d *Daemon) run() error {
 		return err
 	}
 
+	// Start HTTP server for web dashboard
+	store := jsonl.NewStore(d.config.WorkspaceDir)
+	d.httpServer = NewHTTPServer(store, d.config.WorkspaceDir, d.config.StaticFS)
+
+	go func() {
+		addr := fmt.Sprintf(":%d", HTTPPort)
+		fmt.Printf("HTTP server listening on http://localhost%s\n", addr)
+		if err := http.ListenAndServe(addr, d.httpServer.Handler()); err != nil {
+			fmt.Printf("HTTP server error: %v\n", err)
+		}
+	}()
+
 	// Handle signals
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
@@ -193,6 +212,14 @@ func (d *Daemon) runHealthCheck() {
 
 	if err := store.WriteHealth(health); err != nil {
 		fmt.Printf("Error writing health.jsonl: %v\n", err)
+	}
+
+	// Broadcast update to connected web clients
+	if d.httpServer != nil {
+		d.httpServer.Broadcast("health", map[string]interface{}{
+			"timestamp":     time.Now(),
+			"worktreeCount": len(health),
+		})
 	}
 }
 

--- a/internal/daemon/http.go
+++ b/internal/daemon/http.go
@@ -1,0 +1,450 @@
+package daemon
+
+import (
+	"embed"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/joshribakoff/bearing/internal/jsonl"
+)
+
+// HTTPServer serves the web dashboard API and static files
+type HTTPServer struct {
+	store     *jsonl.Store
+	workspace string
+	mu        sync.RWMutex
+	staticFS  fs.FS
+	clients   map[chan []byte]bool
+	clientsMu sync.RWMutex
+}
+
+// NewHTTPServer creates a new HTTP server for the dashboard
+func NewHTTPServer(store *jsonl.Store, workspace string, staticFS fs.FS) *HTTPServer {
+	return &HTTPServer{
+		store:     store,
+		workspace: workspace,
+		staticFS:  staticFS,
+		clients:   make(map[chan []byte]bool),
+	}
+}
+
+// Handler returns the http.Handler for the server
+func (s *HTTPServer) Handler() http.Handler {
+	mux := http.NewServeMux()
+
+	// API endpoints
+	mux.HandleFunc("/api/projects", s.handleProjects)
+	mux.HandleFunc("/api/worktrees", s.handleWorktrees)
+	mux.HandleFunc("/api/plans", s.handlePlans)
+	mux.HandleFunc("/api/prs", s.handlePRs)
+	mux.HandleFunc("/api/health", s.handleHealth)
+	mux.HandleFunc("/api/status", s.handleStatus)
+	mux.HandleFunc("/api/events", s.handleEvents)
+
+	// Static files
+	if s.staticFS != nil {
+		fileServer := http.FileServer(http.FS(s.staticFS))
+		mux.Handle("/", fileServer)
+	}
+
+	return mux
+}
+
+// ProjectResponse for API
+type ProjectResponse struct {
+	Name  string `json:"name"`
+	Count int    `json:"count"`
+}
+
+func (s *HTTPServer) handleProjects(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	local, err := s.store.ReadLocal()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Count worktrees per repo
+	counts := make(map[string]int)
+	for _, e := range local {
+		counts[e.Repo]++
+	}
+
+	// Build unique project list with counts
+	projects := make([]ProjectResponse, 0)
+	seen := make(map[string]bool)
+	for _, e := range local {
+		if !seen[e.Repo] {
+			projects = append(projects, ProjectResponse{
+				Name:  e.Repo,
+				Count: counts[e.Repo],
+			})
+			seen[e.Repo] = true
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(projects)
+}
+
+// WorktreeResponse combines local and health data for API response
+type WorktreeResponse struct {
+	Folder   string  `json:"folder"`
+	Repo     string  `json:"repo"`
+	Branch   string  `json:"branch"`
+	Base     bool    `json:"base"`
+	Purpose  string  `json:"purpose,omitempty"`
+	Status   string  `json:"status,omitempty"`
+	Dirty    bool    `json:"dirty"`
+	Unpushed int     `json:"unpushed"`
+	PRState  *string `json:"prState,omitempty"`
+}
+
+func (s *HTTPServer) handleWorktrees(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	project := r.URL.Query().Get("project")
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	local, err := s.store.ReadLocal()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	workflow, _ := s.store.ReadWorkflow()
+	health, _ := s.store.ReadHealth()
+
+	// Build lookup maps
+	workflowMap := make(map[string]jsonl.WorkflowEntry)
+	for _, wf := range workflow {
+		key := wf.Repo + "/" + wf.Branch
+		workflowMap[key] = wf
+	}
+
+	healthMap := make(map[string]jsonl.HealthEntry)
+	for _, h := range health {
+		healthMap[h.Folder] = h
+	}
+
+	// Combine data - always return array, not null
+	resp := make([]WorktreeResponse, 0)
+	for _, l := range local {
+		if project != "" && l.Repo != project {
+			continue
+		}
+
+		wt := WorktreeResponse{
+			Folder: l.Folder,
+			Repo:   l.Repo,
+			Branch: l.Branch,
+			Base:   l.Base,
+		}
+
+		if wf, ok := workflowMap[l.Repo+"/"+l.Branch]; ok {
+			wt.Purpose = wf.Purpose
+			wt.Status = wf.Status
+		}
+
+		if h, ok := healthMap[l.Folder]; ok {
+			wt.Dirty = h.Dirty
+			wt.Unpushed = h.Unpushed
+			wt.PRState = h.PRState
+		}
+
+		resp = append(resp, wt)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+// PlanResponse for API
+type PlanResponse struct {
+	Project string `json:"project"`
+	Title   string `json:"title"`
+	Issue   string `json:"issue,omitempty"`
+	Status  string `json:"status"`
+	Path    string `json:"path"`
+}
+
+func (s *HTTPServer) handlePlans(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	plansDir := filepath.Join(s.workspace, "plans")
+	plans := make([]PlanResponse, 0)
+
+	filepath.WalkDir(plansDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() || !strings.HasSuffix(path, ".md") {
+			return nil
+		}
+
+		rel, _ := filepath.Rel(plansDir, path)
+		parts := strings.Split(rel, string(os.PathSeparator))
+		if len(parts) < 2 {
+			return nil
+		}
+
+		project := parts[0]
+		fm := parsePlanFrontmatter(path)
+
+		plans = append(plans, PlanResponse{
+			Project: project,
+			Title:   fm["title"],
+			Issue:   fm["issue"],
+			Status:  fm["status"],
+			Path:    rel,
+		})
+
+		return nil
+	})
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(plans)
+}
+
+// PRResponse for API
+type PRResponse struct {
+	Folder string `json:"folder"`
+	Repo   string `json:"repo"`
+	Branch string `json:"branch"`
+	State  string `json:"state"`
+}
+
+func (s *HTTPServer) handlePRs(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	health, err := s.store.ReadHealth()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	local, _ := s.store.ReadLocal()
+	localMap := make(map[string]jsonl.LocalEntry)
+	for _, e := range local {
+		localMap[e.Folder] = e
+	}
+
+	prs := make([]PRResponse, 0)
+	for _, h := range health {
+		if h.PRState == nil {
+			continue
+		}
+		if l, ok := localMap[h.Folder]; ok {
+			prs = append(prs, PRResponse{
+				Folder: h.Folder,
+				Repo:   l.Repo,
+				Branch: l.Branch,
+				State:  *h.PRState,
+			})
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(prs)
+}
+
+// HealthResponse for API
+type HealthResponse struct {
+	DaemonRunning bool      `json:"daemonRunning"`
+	LastCheck     time.Time `json:"lastCheck"`
+	WorktreeCount int       `json:"worktreeCount"`
+}
+
+func (s *HTTPServer) handleHealth(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	health, err := s.store.ReadHealth()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	var lastCheck time.Time
+	for _, h := range health {
+		if h.LastCheck.After(lastCheck) {
+			lastCheck = h.LastCheck
+		}
+	}
+
+	resp := HealthResponse{
+		DaemonRunning: true,
+		LastCheck:     lastCheck,
+		WorktreeCount: len(health),
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+// StatusResponse contains daemon status info
+type StatusResponse struct {
+	Running bool   `json:"running"`
+	Version string `json:"version"`
+}
+
+func (s *HTTPServer) handleStatus(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	resp := StatusResponse{
+		Running: true,
+		Version: "0.1.0",
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+// handleEvents implements Server-Sent Events for real-time updates
+func (s *HTTPServer) handleEvents(w http.ResponseWriter, r *http.Request) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "SSE not supported", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+
+	client := make(chan []byte, 10)
+	s.clientsMu.Lock()
+	s.clients[client] = true
+	s.clientsMu.Unlock()
+
+	defer func() {
+		s.clientsMu.Lock()
+		delete(s.clients, client)
+		s.clientsMu.Unlock()
+		close(client)
+	}()
+
+	// Send initial connected event
+	fmt.Fprintf(w, "event: connected\ndata: {\"status\":\"ok\"}\n\n")
+	flusher.Flush()
+
+	for {
+		select {
+		case msg := <-client:
+			fmt.Fprintf(w, "event: update\ndata: %s\n\n", msg)
+			flusher.Flush()
+		case <-r.Context().Done():
+			return
+		}
+	}
+}
+
+// Broadcast sends an event to all connected SSE clients
+func (s *HTTPServer) Broadcast(eventType string, data interface{}) {
+	msg, err := json.Marshal(map[string]interface{}{
+		"type": eventType,
+		"data": data,
+	})
+	if err != nil {
+		return
+	}
+
+	s.clientsMu.RLock()
+	defer s.clientsMu.RUnlock()
+
+	for client := range s.clients {
+		select {
+		case client <- msg:
+		default:
+			// Client buffer full, skip
+		}
+	}
+}
+
+// parsePlanFrontmatter parses YAML frontmatter from a plan file
+func parsePlanFrontmatter(path string) map[string]string {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return map[string]string{"title": filepath.Base(path)}
+	}
+
+	lines := strings.Split(string(content), "\n")
+	fm := make(map[string]string)
+	inFrontmatter := false
+
+	for i, line := range lines {
+		if strings.TrimSpace(line) == "---" {
+			if !inFrontmatter && i == 0 {
+				inFrontmatter = true
+				continue
+			} else if inFrontmatter {
+				break
+			}
+		} else if inFrontmatter {
+			if idx := strings.Index(line, ":"); idx > 0 {
+				key := strings.TrimSpace(line[:idx])
+				value := strings.TrimSpace(line[idx+1:])
+				value = strings.Trim(value, "\"'")
+				fm[key] = value
+			}
+		}
+	}
+
+	// Extract title from first heading if not in frontmatter
+	if fm["title"] == "" {
+		headingRe := regexp.MustCompile(`^#\s+(.+)$`)
+		for _, line := range lines {
+			if m := headingRe.FindStringSubmatch(line); len(m) > 1 {
+				fm["title"] = m[1]
+				break
+			}
+		}
+	}
+
+	if fm["title"] == "" {
+		fm["title"] = filepath.Base(path)
+	}
+	if fm["status"] == "" {
+		fm["status"] = "draft"
+	}
+
+	return fm
+}
+
+// EmbeddedStaticFS is a placeholder for the embedded web assets
+var EmbeddedStaticFS embed.FS

--- a/internal/daemon/http_test.go
+++ b/internal/daemon/http_test.go
@@ -1,0 +1,478 @@
+package daemon
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/joshribakoff/bearing/internal/jsonl"
+)
+
+func setupTestStore(t *testing.T) (*jsonl.Store, string) {
+	t.Helper()
+	dir := t.TempDir()
+
+	// Create test local.jsonl
+	localPath := filepath.Join(dir, "local.jsonl")
+	localData := `{"folder":"project-main","repo":"project","branch":"main","base":true}
+{"folder":"project-feature","repo":"project","branch":"feature-1","base":false}
+`
+	if err := os.WriteFile(localPath, []byte(localData), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create test health.jsonl
+	healthPath := filepath.Join(dir, "health.jsonl")
+	healthData := `{"folder":"project-main","dirty":false,"unpushed":0,"lastCheck":"2024-01-01T00:00:00Z"}
+{"folder":"project-feature","dirty":true,"unpushed":2,"prState":"OPEN","lastCheck":"2024-01-01T00:00:00Z"}
+`
+	if err := os.WriteFile(healthPath, []byte(healthData), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create test projects.jsonl
+	projectsPath := filepath.Join(dir, "projects.jsonl")
+	projectsData := `{"name":"project","github_repo":"user/project","path":"/path/to/project"}
+`
+	if err := os.WriteFile(projectsPath, []byte(projectsData), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	return jsonl.NewStore(dir), dir
+}
+
+func TestHandleWorktrees(t *testing.T) {
+	store, dir := setupTestStore(t)
+	server := NewHTTPServer(store, dir, nil)
+	handler := server.Handler()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/worktrees", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rec.Code)
+	}
+
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("expected Content-Type application/json, got %s", ct)
+	}
+
+	var resp []WorktreeResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if len(resp) != 2 {
+		t.Fatalf("expected 2 worktrees, got %d", len(resp))
+	}
+
+	// Check first worktree (base)
+	if resp[0].Folder != "project-main" {
+		t.Errorf("expected folder project-main, got %s", resp[0].Folder)
+	}
+	if !resp[0].Base {
+		t.Error("expected first worktree to be base")
+	}
+	if resp[0].Dirty {
+		t.Error("expected first worktree to not be dirty")
+	}
+
+	// Check second worktree (feature)
+	if resp[1].Folder != "project-feature" {
+		t.Errorf("expected folder project-feature, got %s", resp[1].Folder)
+	}
+	if resp[1].Base {
+		t.Error("expected second worktree to not be base")
+	}
+	if !resp[1].Dirty {
+		t.Error("expected second worktree to be dirty")
+	}
+	if resp[1].Unpushed != 2 {
+		t.Errorf("expected 2 unpushed, got %d", resp[1].Unpushed)
+	}
+	if resp[1].PRState == nil || *resp[1].PRState != "OPEN" {
+		t.Error("expected PRState to be OPEN")
+	}
+}
+
+func TestHandleWorktrees_MethodNotAllowed(t *testing.T) {
+	store, dir := setupTestStore(t)
+	server := NewHTTPServer(store, dir, nil)
+	handler := server.Handler()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/worktrees", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected status 405, got %d", rec.Code)
+	}
+}
+
+func TestHandleWorktrees_FilterByProject(t *testing.T) {
+	store, dir := setupTestStore(t)
+	server := NewHTTPServer(store, dir, nil)
+	handler := server.Handler()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/worktrees?project=project", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rec.Code)
+	}
+
+	var resp []WorktreeResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if len(resp) != 2 {
+		t.Fatalf("expected 2 worktrees for project, got %d", len(resp))
+	}
+
+	// Test with non-existent project
+	req = httptest.NewRequest(http.MethodGet, "/api/worktrees?project=nonexistent", nil)
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if len(resp) != 0 {
+		t.Errorf("expected 0 worktrees for nonexistent project, got %d", len(resp))
+	}
+}
+
+func TestHandleHealth(t *testing.T) {
+	store, dir := setupTestStore(t)
+	server := NewHTTPServer(store, dir, nil)
+	handler := server.Handler()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/health", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rec.Code)
+	}
+
+	var resp HealthResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if !resp.DaemonRunning {
+		t.Error("expected daemon running to be true")
+	}
+	if resp.WorktreeCount != 2 {
+		t.Errorf("expected 2 worktrees, got %d", resp.WorktreeCount)
+	}
+}
+
+func TestHandleProjects(t *testing.T) {
+	store, dir := setupTestStore(t)
+	server := NewHTTPServer(store, dir, nil)
+	handler := server.Handler()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/projects", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rec.Code)
+	}
+
+	var resp []ProjectResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if len(resp) != 1 {
+		t.Fatalf("expected 1 project, got %d", len(resp))
+	}
+
+	if resp[0].Name != "project" {
+		t.Errorf("expected project name 'project', got %s", resp[0].Name)
+	}
+	if resp[0].Count != 2 {
+		t.Errorf("expected count 2, got %d", resp[0].Count)
+	}
+}
+
+func TestHandlePRs(t *testing.T) {
+	store, dir := setupTestStore(t)
+	server := NewHTTPServer(store, dir, nil)
+	handler := server.Handler()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/prs", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rec.Code)
+	}
+
+	var resp []PRResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	// Only project-feature has a PR
+	if len(resp) != 1 {
+		t.Fatalf("expected 1 PR, got %d", len(resp))
+	}
+
+	if resp[0].State != "OPEN" {
+		t.Errorf("expected PR state OPEN, got %s", resp[0].State)
+	}
+}
+
+func TestHandlePlans(t *testing.T) {
+	store, dir := setupTestStore(t)
+
+	// Create plans directory with a test plan
+	plansDir := filepath.Join(dir, "plans", "testproject")
+	if err := os.MkdirAll(plansDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	planContent := `---
+title: Test Plan
+status: active
+issue: "#123"
+---
+
+# Test Plan
+
+This is a test plan.
+`
+	if err := os.WriteFile(filepath.Join(plansDir, "001-test.md"), []byte(planContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	server := NewHTTPServer(store, dir, nil)
+	handler := server.Handler()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/plans", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rec.Code)
+	}
+
+	var resp []PlanResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if len(resp) != 1 {
+		t.Fatalf("expected 1 plan, got %d", len(resp))
+	}
+
+	if resp[0].Title != "Test Plan" {
+		t.Errorf("expected title 'Test Plan', got %s", resp[0].Title)
+	}
+	if resp[0].Status != "active" {
+		t.Errorf("expected status 'active', got %s", resp[0].Status)
+	}
+	if resp[0].Project != "testproject" {
+		t.Errorf("expected project 'testproject', got %s", resp[0].Project)
+	}
+}
+
+func TestHandleStatus(t *testing.T) {
+	store, dir := setupTestStore(t)
+	server := NewHTTPServer(store, dir, nil)
+	handler := server.Handler()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/status", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rec.Code)
+	}
+
+	var resp StatusResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if !resp.Running {
+		t.Error("expected running to be true")
+	}
+	if resp.Version == "" {
+		t.Error("expected version to be set")
+	}
+}
+
+func TestStaticFileServing(t *testing.T) {
+	store, dir := setupTestStore(t)
+
+	// Create static files
+	staticDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(staticDir, "index.html"), []byte("<!DOCTYPE html><html><body>Hello</body></html>"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(staticDir, "app.js"), []byte("console.log('hello');"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	server := NewHTTPServer(store, dir, os.DirFS(staticDir))
+
+	// Use httptest.Server for proper request handling
+	ts := httptest.NewServer(server.Handler())
+	defer ts.Close()
+
+	// Test index.html
+	resp, err := http.Get(ts.URL + "/index.html")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected status 200, got %d", resp.StatusCode)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "<!DOCTYPE html><html><body>Hello</body></html>" {
+		t.Errorf("unexpected body: %s", string(body))
+	}
+
+	// Test app.js
+	resp2, err := http.Get(ts.URL + "/app.js")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp2.Body.Close()
+
+	if resp2.StatusCode != http.StatusOK {
+		t.Errorf("expected status 200, got %d", resp2.StatusCode)
+	}
+}
+
+func TestEmptyStore(t *testing.T) {
+	// Test with empty directory (no JSONL files)
+	dir := t.TempDir()
+	store := jsonl.NewStore(dir)
+	server := NewHTTPServer(store, dir, nil)
+	handler := server.Handler()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/worktrees", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rec.Code)
+	}
+
+	var resp []WorktreeResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	// Should return empty array, not null
+	if len(resp) != 0 {
+		t.Errorf("expected empty array, got %d items", len(resp))
+	}
+}
+
+func TestHandleEvents_SSE(t *testing.T) {
+	store, dir := setupTestStore(t)
+	server := NewHTTPServer(store, dir, nil)
+
+	ts := httptest.NewServer(server.Handler())
+	defer ts.Close()
+
+	// Make SSE request
+	resp, err := http.Get(ts.URL + "/api/events")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected status 200, got %d", resp.StatusCode)
+	}
+
+	if ct := resp.Header.Get("Content-Type"); ct != "text/event-stream" {
+		t.Errorf("expected Content-Type text/event-stream, got %s", ct)
+	}
+
+	// Read initial connected event
+	buf := make([]byte, 1024)
+	n, err := resp.Body.Read(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	data := string(buf[:n])
+	if !contains(data, "event: connected") {
+		t.Errorf("expected connected event, got: %s", data)
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsAt(s, substr, 0))
+}
+
+func containsAt(s, substr string, start int) bool {
+	for i := start; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}
+
+func TestParsePlanFrontmatter(t *testing.T) {
+	dir := t.TempDir()
+
+	// Test with frontmatter
+	planWithFM := `---
+title: My Plan
+status: active
+issue: "#42"
+---
+
+# Content
+`
+	path1 := filepath.Join(dir, "plan1.md")
+	if err := os.WriteFile(path1, []byte(planWithFM), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	fm := parsePlanFrontmatter(path1)
+	if fm["title"] != "My Plan" {
+		t.Errorf("expected title 'My Plan', got %s", fm["title"])
+	}
+	if fm["status"] != "active" {
+		t.Errorf("expected status 'active', got %s", fm["status"])
+	}
+
+	// Test without frontmatter (extract from heading)
+	planNoFM := `# Heading Title
+
+Some content.
+`
+	path2 := filepath.Join(dir, "plan2.md")
+	if err := os.WriteFile(path2, []byte(planNoFM), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	fm2 := parsePlanFrontmatter(path2)
+	if fm2["title"] != "Heading Title" {
+		t.Errorf("expected title 'Heading Title', got %s", fm2["title"])
+	}
+	if fm2["status"] != "draft" {
+		t.Errorf("expected default status 'draft', got %s", fm2["status"])
+	}
+}

--- a/internal/jsonl/store.go
+++ b/internal/jsonl/store.go
@@ -32,6 +32,11 @@ func (s *Store) HealthPath() string {
 	return filepath.Join(s.baseDir, "health.jsonl")
 }
 
+// ProjectsPath returns the path to projects.jsonl
+func (s *Store) ProjectsPath() string {
+	return filepath.Join(s.baseDir, "projects.jsonl")
+}
+
 // ReadWorkflow reads all workflow entries
 func (s *Store) ReadWorkflow() ([]WorkflowEntry, error) {
 	return readJSONL[WorkflowEntry](s.WorkflowPath())
@@ -45,6 +50,11 @@ func (s *Store) ReadLocal() ([]LocalEntry, error) {
 // ReadHealth reads all health entries
 func (s *Store) ReadHealth() ([]HealthEntry, error) {
 	return readJSONL[HealthEntry](s.HealthPath())
+}
+
+// ReadProjects reads all project entries
+func (s *Store) ReadProjects() ([]ProjectEntry, error) {
+	return readJSONL[ProjectEntry](s.ProjectsPath())
 }
 
 // WriteWorkflow writes all workflow entries (overwrites)

--- a/test/integration/http_test.go
+++ b/test/integration/http_test.go
@@ -1,0 +1,292 @@
+package integration
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/joshribakoff/bearing/internal/daemon"
+	"github.com/joshribakoff/bearing/internal/jsonl"
+)
+
+// TestHTTPServerIntegration tests the HTTP server with real JSONL files
+func TestHTTPServerIntegration(t *testing.T) {
+	// Create temp workspace
+	workspace := t.TempDir()
+
+	// Create realistic local.jsonl
+	localData := []jsonl.LocalEntry{
+		{Folder: "project-main", Repo: "project", Branch: "main", Base: true},
+		{Folder: "project-feature", Repo: "project", Branch: "feature/add-tests", Base: false},
+		{Folder: "other-main", Repo: "other", Branch: "main", Base: true},
+	}
+	writeJSONL(t, filepath.Join(workspace, "local.jsonl"), localData)
+
+	// Create realistic health.jsonl
+	healthData := []jsonl.HealthEntry{
+		{Folder: "project-main", Dirty: false, Unpushed: 0},
+		{Folder: "project-feature", Dirty: true, Unpushed: 3},
+		{Folder: "other-main", Dirty: false, Unpushed: 0},
+	}
+	writeJSONL(t, filepath.Join(workspace, "health.jsonl"), healthData)
+
+	// Create plans directory
+	plansDir := filepath.Join(workspace, "plans", "project")
+	if err := os.MkdirAll(plansDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	planContent := `---
+title: Add Testing Infrastructure
+status: in-progress
+issue: "#42"
+---
+
+# Add Testing Infrastructure
+
+This plan covers adding comprehensive tests.
+`
+	if err := os.WriteFile(filepath.Join(plansDir, "001-testing.md"), []byte(planContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create static files
+	staticDir := filepath.Join(workspace, "web")
+	if err := os.MkdirAll(staticDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	indexHTML := `<!DOCTYPE html>
+<html>
+<head><title>Bearing Dashboard</title></head>
+<body><h1>Bearing</h1></body>
+</html>`
+	if err := os.WriteFile(filepath.Join(staticDir, "index.html"), []byte(indexHTML), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create server
+	store := jsonl.NewStore(workspace)
+	server := daemon.NewHTTPServer(store, workspace, os.DirFS(staticDir))
+	ts := httptest.NewServer(server.Handler())
+	defer ts.Close()
+
+	t.Run("serves index.html", func(t *testing.T) {
+		resp, err := http.Get(ts.URL + "/index.html")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("expected 200, got %d", resp.StatusCode)
+		}
+
+		body, _ := io.ReadAll(resp.Body)
+		if len(body) == 0 {
+			t.Error("expected non-empty body")
+		}
+		if !contains(string(body), "Bearing") {
+			t.Error("expected body to contain 'Bearing'")
+		}
+	})
+
+	t.Run("worktrees returns combined data", func(t *testing.T) {
+		resp, err := http.Get(ts.URL + "/api/worktrees")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		var worktrees []daemon.WorktreeResponse
+		if err := json.NewDecoder(resp.Body).Decode(&worktrees); err != nil {
+			t.Fatal(err)
+		}
+
+		if len(worktrees) != 3 {
+			t.Fatalf("expected 3 worktrees, got %d", len(worktrees))
+		}
+
+		// Find feature worktree and check health data is merged
+		for _, wt := range worktrees {
+			if wt.Folder == "project-feature" {
+				if !wt.Dirty {
+					t.Error("expected project-feature to be dirty")
+				}
+				if wt.Unpushed != 3 {
+					t.Errorf("expected 3 unpushed, got %d", wt.Unpushed)
+				}
+			}
+		}
+	})
+
+	t.Run("worktrees filters by project", func(t *testing.T) {
+		resp, err := http.Get(ts.URL + "/api/worktrees?project=project")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		var worktrees []daemon.WorktreeResponse
+		if err := json.NewDecoder(resp.Body).Decode(&worktrees); err != nil {
+			t.Fatal(err)
+		}
+
+		if len(worktrees) != 2 {
+			t.Fatalf("expected 2 worktrees for 'project', got %d", len(worktrees))
+		}
+
+		for _, wt := range worktrees {
+			if wt.Repo != "project" {
+				t.Errorf("expected repo 'project', got '%s'", wt.Repo)
+			}
+		}
+	})
+
+	t.Run("projects returns unique projects with counts", func(t *testing.T) {
+		resp, err := http.Get(ts.URL + "/api/projects")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		var projects []daemon.ProjectResponse
+		if err := json.NewDecoder(resp.Body).Decode(&projects); err != nil {
+			t.Fatal(err)
+		}
+
+		if len(projects) != 2 {
+			t.Fatalf("expected 2 projects, got %d", len(projects))
+		}
+
+		// Check counts
+		for _, p := range projects {
+			if p.Name == "project" && p.Count != 2 {
+				t.Errorf("expected count 2 for 'project', got %d", p.Count)
+			}
+			if p.Name == "other" && p.Count != 1 {
+				t.Errorf("expected count 1 for 'other', got %d", p.Count)
+			}
+		}
+	})
+
+	t.Run("plans returns plan list", func(t *testing.T) {
+		resp, err := http.Get(ts.URL + "/api/plans")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		var plans []daemon.PlanResponse
+		if err := json.NewDecoder(resp.Body).Decode(&plans); err != nil {
+			t.Fatal(err)
+		}
+
+		if len(plans) != 1 {
+			t.Fatalf("expected 1 plan, got %d", len(plans))
+		}
+
+		if plans[0].Title != "Add Testing Infrastructure" {
+			t.Errorf("expected title 'Add Testing Infrastructure', got '%s'", plans[0].Title)
+		}
+		if plans[0].Status != "in-progress" {
+			t.Errorf("expected status 'in-progress', got '%s'", plans[0].Status)
+		}
+	})
+
+	t.Run("health returns aggregated health", func(t *testing.T) {
+		resp, err := http.Get(ts.URL + "/api/health")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		var health daemon.HealthResponse
+		if err := json.NewDecoder(resp.Body).Decode(&health); err != nil {
+			t.Fatal(err)
+		}
+
+		if !health.DaemonRunning {
+			t.Error("expected daemon running to be true")
+		}
+		if health.WorktreeCount != 3 {
+			t.Errorf("expected 3 worktrees, got %d", health.WorktreeCount)
+		}
+	})
+}
+
+// TestHTTPServerEmptyWorkspace tests behavior with no data
+func TestHTTPServerEmptyWorkspace(t *testing.T) {
+	workspace := t.TempDir()
+	store := jsonl.NewStore(workspace)
+	server := daemon.NewHTTPServer(store, workspace, nil)
+	ts := httptest.NewServer(server.Handler())
+	defer ts.Close()
+
+	t.Run("worktrees returns empty array", func(t *testing.T) {
+		resp, err := http.Get(ts.URL + "/api/worktrees")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		body, _ := io.ReadAll(resp.Body)
+		// Should be empty array, not null
+		if string(body) != "[]\n" {
+			t.Errorf("expected '[]\\n', got '%s'", string(body))
+		}
+	})
+
+	t.Run("projects returns empty array", func(t *testing.T) {
+		resp, err := http.Get(ts.URL + "/api/projects")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		body, _ := io.ReadAll(resp.Body)
+		if string(body) != "[]\n" {
+			t.Errorf("expected '[]\\n', got '%s'", string(body))
+		}
+	})
+
+	t.Run("plans returns empty array", func(t *testing.T) {
+		resp, err := http.Get(ts.URL + "/api/plans")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		body, _ := io.ReadAll(resp.Body)
+		if string(body) != "[]\n" {
+			t.Errorf("expected '[]\\n', got '%s'", string(body))
+		}
+	})
+}
+
+func writeJSONL[T any](t *testing.T, path string, entries []T) {
+	t.Helper()
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	enc := json.NewEncoder(f)
+	for _, e := range entries {
+		if err := enc.Encode(e); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func contains(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/tui/bearing_tui/widgets/projects.py
+++ b/tui/bearing_tui/widgets/projects.py
@@ -20,6 +20,11 @@ class ProjectListItem(ListItem):
             text.append(f" ({self.count})", style="dim cyan")
         yield Static(text, markup=False)
 
+    def on_click(self, event) -> None:
+        """Focus parent list when item is clicked."""
+        if self.parent:
+            self.parent.focus()
+
 
 class ProjectList(ListView):
     """Left panel showing list of repos/projects."""
@@ -43,6 +48,10 @@ class ProjectList(ListView):
         """Handle selection and emit ProjectSelected message."""
         if isinstance(event.item, ProjectListItem):
             self.post_message(self.ProjectSelected(event.item.project))
+
+    def on_click(self, event) -> None:
+        """Focus the list when clicked."""
+        self.focus()
 
     def set_projects(self, projects: list[str], counts: dict[str, int] | None = None, preserve_selection: str | None = None) -> None:
         """Update the project list with optional worktree counts.

--- a/tui/tests/test_comprehensive.py
+++ b/tui/tests/test_comprehensive.py
@@ -555,3 +555,112 @@ async def test_worktree_selection_triggers_details(workspace):
 
         # Details should now have a folder set
         assert details.current_folder is not None
+
+
+# ============================================================================
+# Mouse Click Support
+# ============================================================================
+
+@pytest.mark.asyncio
+async def test_project_list_mouse_click_selects(workspace):
+    """Test that clicking on a project list item selects it."""
+    app = BearingApp(workspace=workspace)
+    async with app.run_test(size=(100, 25)) as pilot:
+        await pilot.pause()
+
+        project_list = app.query_one(ProjectList)
+        worktree_table = app.query_one(WorktreeTable)
+
+        # Get the second project item (index 1)
+        items = list(project_list.query("ProjectListItem"))
+        assert len(items) >= 2, "Need at least 2 projects for this test"
+
+        target_item = items[1]  # Second project
+
+        # Click on the item
+        await pilot.click(target_item)
+        await pilot.pause()
+
+        # Project should be selected (worktree table populated)
+        assert worktree_table.row_count > 0
+        # The current project should be set
+        assert app._current_project is not None
+
+
+@pytest.mark.asyncio
+async def test_worktree_table_mouse_click_selects(workspace):
+    """Test that clicking on a worktree table row selects it."""
+    app = BearingApp(workspace=workspace)
+    async with app.run_test(size=(100, 25)) as pilot:
+        await pilot.pause()
+
+        # First select a project to populate worktrees
+        await pilot.press("0")
+        await pilot.press("j")
+        await pilot.press("enter")
+        await pilot.pause()
+
+        worktree_table = app.query_one(WorktreeTable)
+        details = app.query_one(DetailsPanel)
+
+        assert worktree_table.row_count > 1, "Need multiple worktrees for this test"
+
+        # Click on the worktree table - clicking the widget moves cursor
+        await pilot.click(worktree_table)
+        await pilot.pause()
+
+        # Now double-click or use Enter to trigger selection
+        # DataTable requires Enter or double-click to emit RowSelected
+        await pilot.press("enter")
+        await pilot.pause()
+
+        # Details panel should be updated
+        assert details.current_folder is not None
+
+
+@pytest.mark.asyncio
+async def test_mouse_click_focuses_panel(workspace):
+    """Test that clicking on a panel focuses it."""
+    app = BearingApp(workspace=workspace)
+    async with app.run_test(size=(100, 25)) as pilot:
+        await pilot.pause()
+
+        project_list = app.query_one(ProjectList)
+        worktree_table = app.query_one(WorktreeTable)
+
+        # Start focused on project list
+        await pilot.press("0")
+        await pilot.pause()
+        assert app.focused.id == "project-list"
+
+        # Click on worktree table
+        await pilot.click(worktree_table)
+        await pilot.pause()
+
+        # Focus should move to worktree table
+        assert app.focused.id == "worktree-table"
+
+        # Note: Clicking on a project list item selects the project AND
+        # automatically focuses the worktree table (by design - see
+        # on_project_list_project_selected). This is good UX - after selecting
+        # a project, you typically want to interact with its worktrees.
+
+
+@pytest.mark.asyncio
+async def test_mouse_click_on_worktree_table_focuses(workspace):
+    """Test that clicking on the worktree table focuses it."""
+    app = BearingApp(workspace=workspace)
+    async with app.run_test(size=(100, 25)) as pilot:
+        await pilot.pause()
+
+        worktree_table = app.query_one(WorktreeTable)
+
+        # Start focused on project list
+        await pilot.press("0")
+        await pilot.pause()
+        assert app.focused.id == "project-list"
+
+        # Click on worktree table - should focus it
+        await pilot.click(worktree_table)
+        await pilot.pause()
+        assert app.focused.id == "worktree-table"

--- a/web/app.js
+++ b/web/app.js
@@ -46,14 +46,51 @@ function init() {
   els.plansModal = document.getElementById('plans-modal');
   els.plansList = document.getElementById('plans-list');
 
+  // Restore persisted state
+  loadState();
+
   // Setup event listeners
   setupKeyboardNavigation();
   setupClickHandlers();
   setupTabHandlers();
   connectSSE();
 
+  // Restore view and sort indicators
+  if (state.currentView !== 'worktrees') {
+    switchView(state.currentView);
+  }
+  updateSortIndicators();
+
   // Initial data load
   refresh();
+}
+
+// State persistence
+function saveState() {
+  const persisted = {
+    selectedProject: state.selectedProject,
+    worktreeIndex: state.worktreeIndex,
+    sortColumn: state.sortColumn,
+    sortDirection: state.sortDirection,
+    currentView: state.currentView,
+  };
+  localStorage.setItem('bearing-state', JSON.stringify(persisted));
+}
+
+function loadState() {
+  try {
+    const saved = localStorage.getItem('bearing-state');
+    if (saved) {
+      const persisted = JSON.parse(saved);
+      state.selectedProject = persisted.selectedProject || null;
+      state.worktreeIndex = persisted.worktreeIndex || 0;
+      state.sortColumn = persisted.sortColumn || 'default';
+      state.sortDirection = persisted.sortDirection || 'asc';
+      state.currentView = persisted.currentView || 'worktrees';
+    }
+  } catch (e) {
+    console.warn('Failed to load persisted state:', e);
+  }
 }
 
 // Data fetching
@@ -161,6 +198,7 @@ function handleSort(column) {
   }
   updateSortIndicators();
   renderWorktrees();
+  saveState();
 }
 
 function updateSortIndicators() {
@@ -275,6 +313,7 @@ function selectProject(name) {
   });
 
   renderWorktrees();
+  saveState();
 }
 
 function selectWorktree(index) {
@@ -288,6 +327,7 @@ function selectWorktree(index) {
   });
 
   updateDetails(filtered[index]);
+  saveState();
 }
 
 // Keyboard navigation
@@ -663,4 +703,5 @@ switchView = function(view) {
     placeholder.style.display = 'none';
   }
   originalSwitchView(view);
+  saveState();
 };

--- a/web/app.js
+++ b/web/app.js
@@ -1,6 +1,6 @@
 // Bearing Web Dashboard - Vanilla JS Application
 
-const API_BASE = '';
+const API_BASE = 'http://localhost:8374';
 
 // State
 const state = {

--- a/web/app.js
+++ b/web/app.js
@@ -1,0 +1,538 @@
+// Bearing Web Dashboard - Vanilla JS Application
+
+const API_BASE = '';
+
+// State
+const state = {
+  projects: [],
+  worktrees: [],
+  plans: [],
+  selectedProject: null,
+  selectedWorktree: null,
+  selectedPlan: null,
+  focusedPanel: 'project-list',
+  projectIndex: 0,
+  worktreeIndex: 0,
+  planIndex: 0,
+  evtSource: null,
+};
+
+// DOM elements
+const els = {
+  projectList: null,
+  worktreeRows: null,
+  detailsContent: null,
+  statusIndicator: null,
+  helpModal: null,
+  plansModal: null,
+  plansList: null,
+};
+
+// Initialize
+document.addEventListener('DOMContentLoaded', init);
+
+function init() {
+  // Cache DOM elements
+  els.projectList = document.getElementById('project-list');
+  els.worktreeRows = document.getElementById('worktree-rows');
+  els.detailsContent = document.getElementById('details-content');
+  els.statusIndicator = document.getElementById('status-indicator');
+  els.helpModal = document.getElementById('help-modal');
+  els.plansModal = document.getElementById('plans-modal');
+  els.plansList = document.getElementById('plans-list');
+
+  // Setup event listeners
+  setupKeyboardNavigation();
+  setupClickHandlers();
+  connectSSE();
+
+  // Initial data load
+  refresh();
+}
+
+// Data fetching
+async function fetchJSON(url) {
+  const resp = await fetch(API_BASE + url);
+  if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+  return resp.json();
+}
+
+async function refresh() {
+  try {
+    const [projects, worktrees] = await Promise.all([
+      fetchJSON('/api/projects'),
+      fetchJSON('/api/worktrees'),
+    ]);
+
+    state.projects = projects || [];
+    state.worktrees = worktrees || [];
+
+    renderProjects();
+
+    // Restore selection or select first
+    if (state.selectedProject) {
+      const idx = state.projects.findIndex(p => p.name === state.selectedProject);
+      if (idx >= 0) {
+        state.projectIndex = idx;
+        selectProject(state.selectedProject);
+      } else if (state.projects.length > 0) {
+        state.projectIndex = 0;
+        selectProject(state.projects[0].name);
+      }
+    } else if (state.projects.length > 0) {
+      state.projectIndex = 0;
+      selectProject(state.projects[0].name);
+    }
+  } catch (err) {
+    console.error('Refresh failed:', err);
+    showError('Failed to load data');
+  }
+}
+
+async function loadPlans() {
+  try {
+    state.plans = await fetchJSON('/api/plans') || [];
+    renderPlans();
+  } catch (err) {
+    console.error('Failed to load plans:', err);
+  }
+}
+
+// Rendering
+function renderProjects() {
+  els.projectList.innerHTML = state.projects.map((p, i) => `
+    <li class="list-item ${i === state.projectIndex ? 'selected' : ''}"
+        data-project="${p.name}" data-index="${i}">
+      <span class="project-name">${escapeHtml(p.name)}</span>
+      <span class="project-count">${p.count}</span>
+    </li>
+  `).join('');
+}
+
+function renderWorktrees() {
+  const filtered = state.worktrees.filter(w => w.repo === state.selectedProject);
+
+  els.worktreeRows.innerHTML = filtered.map((w, i) => {
+    const statusParts = [];
+    if (w.dirty) statusParts.push('<span class="status-dirty">*</span>');
+    if (w.unpushed > 0) statusParts.push(`<span class="status-unpushed">${w.unpushed}↑</span>`);
+    if (!w.dirty && w.unpushed === 0) statusParts.push('<span class="status-clean">✓</span>');
+
+    let prBadge = '';
+    if (w.prState) {
+      const cls = `pr-${w.prState.toLowerCase()}`;
+      prBadge = `<span class="${cls}">${w.prState}</span>`;
+    }
+
+    const baseTag = w.base ? '<span class="base-indicator">BASE</span>' : '';
+
+    return `
+      <div class="table-row ${i === state.worktreeIndex ? 'selected' : ''}"
+           data-folder="${w.folder}" data-index="${i}">
+        <span class="col-folder">${escapeHtml(w.folder)}${baseTag}</span>
+        <span class="col-branch">${escapeHtml(w.branch)}</span>
+        <span class="col-status">${statusParts.join(' ')}</span>
+        <span class="col-pr">${prBadge}</span>
+      </div>
+    `;
+  }).join('');
+
+  // Update details if we have a selection
+  if (filtered.length > 0 && state.worktreeIndex < filtered.length) {
+    updateDetails(filtered[state.worktreeIndex]);
+  } else {
+    clearDetails();
+  }
+}
+
+function renderPlans() {
+  els.plansList.innerHTML = state.plans.map((p, i) => `
+    <div class="list-item ${i === state.planIndex ? 'selected' : ''}"
+         data-index="${i}" data-issue="${p.issue || ''}">
+      <span class="plan-status ${p.status}"></span>
+      <span class="plan-title">${escapeHtml(p.title)}</span>
+      <span class="plan-project">${escapeHtml(p.project)}</span>
+      <span class="plan-issue">${p.issue ? '#' + p.issue : ''}</span>
+    </div>
+  `).join('');
+}
+
+function updateDetails(worktree) {
+  if (!worktree) {
+    clearDetails();
+    return;
+  }
+
+  state.selectedWorktree = worktree;
+
+  const rows = [
+    { label: 'Folder:', value: worktree.folder },
+    { label: 'Repo:', value: worktree.repo },
+    { label: 'Branch:', value: worktree.branch },
+    { label: 'Base:', value: worktree.base ? 'Yes' : 'No' },
+  ];
+
+  if (worktree.purpose) {
+    rows.push({ label: 'Purpose:', value: worktree.purpose });
+  }
+  if (worktree.status) {
+    rows.push({ label: 'Status:', value: worktree.status });
+  }
+
+  const healthRow = [];
+  if (worktree.dirty) healthRow.push('Uncommitted changes');
+  if (worktree.unpushed > 0) healthRow.push(`${worktree.unpushed} unpushed`);
+  if (worktree.prState) healthRow.push(`PR: ${worktree.prState}`);
+  if (healthRow.length > 0) {
+    rows.push({ label: 'Health:', value: healthRow.join(', ') });
+  }
+
+  els.detailsContent.innerHTML = rows.map(r => `
+    <div class="detail-row">
+      <span class="detail-label">${r.label}</span>
+      <span class="detail-value">${escapeHtml(r.value)}</span>
+    </div>
+  `).join('');
+}
+
+function clearDetails() {
+  state.selectedWorktree = null;
+  els.detailsContent.innerHTML = '<span style="color: var(--text-dim)">Select a worktree to view details</span>';
+}
+
+// Selection
+function selectProject(name) {
+  state.selectedProject = name;
+  state.worktreeIndex = 0;
+
+  // Update project list selection
+  els.projectList.querySelectorAll('.list-item').forEach((el, i) => {
+    el.classList.toggle('selected', el.dataset.project === name);
+    if (el.dataset.project === name) state.projectIndex = i;
+  });
+
+  renderWorktrees();
+}
+
+function selectWorktree(index) {
+  const filtered = state.worktrees.filter(w => w.repo === state.selectedProject);
+  if (index < 0 || index >= filtered.length) return;
+
+  state.worktreeIndex = index;
+
+  els.worktreeRows.querySelectorAll('.table-row').forEach((el, i) => {
+    el.classList.toggle('selected', i === index);
+  });
+
+  updateDetails(filtered[index]);
+}
+
+// Keyboard navigation
+function setupKeyboardNavigation() {
+  document.addEventListener('keydown', (e) => {
+    // Modals take priority
+    if (!els.helpModal.classList.contains('hidden')) {
+      if (e.key === 'Escape' || e.key === '?') {
+        closeHelp();
+        e.preventDefault();
+      }
+      return;
+    }
+
+    if (!els.plansModal.classList.contains('hidden')) {
+      handlePlansKeys(e);
+      return;
+    }
+
+    // Global keys
+    switch (e.key) {
+      case '?':
+        openHelp();
+        e.preventDefault();
+        break;
+      case 'p':
+        openPlans();
+        e.preventDefault();
+        break;
+      case 'r':
+        refresh();
+        e.preventDefault();
+        break;
+      case 'o':
+        openPR();
+        e.preventDefault();
+        break;
+      case '0':
+        focusPanel('project-list');
+        e.preventDefault();
+        break;
+      case '1':
+        focusPanel('worktree-table');
+        e.preventDefault();
+        break;
+      case '2':
+        focusPanel('details-panel');
+        e.preventDefault();
+        break;
+      case 'h':
+      case 'ArrowLeft':
+        focusPanel('project-list');
+        e.preventDefault();
+        break;
+      case 'l':
+      case 'ArrowRight':
+        if (state.focusedPanel === 'project-list') {
+          focusPanel('worktree-table');
+        }
+        e.preventDefault();
+        break;
+      case 'j':
+      case 'ArrowDown':
+        navigateDown();
+        e.preventDefault();
+        break;
+      case 'k':
+      case 'ArrowUp':
+        navigateUp();
+        e.preventDefault();
+        break;
+      case 'Enter':
+        handleEnter();
+        e.preventDefault();
+        break;
+      case 'Tab':
+        if (e.shiftKey) {
+          focusPrevPanel();
+        } else {
+          focusNextPanel();
+        }
+        e.preventDefault();
+        break;
+    }
+  });
+}
+
+function handlePlansKeys(e) {
+  switch (e.key) {
+    case 'Escape':
+    case 'p':
+      closePlans();
+      e.preventDefault();
+      break;
+    case 'j':
+    case 'ArrowDown':
+      if (state.planIndex < state.plans.length - 1) {
+        state.planIndex++;
+        renderPlans();
+      }
+      e.preventDefault();
+      break;
+    case 'k':
+    case 'ArrowUp':
+      if (state.planIndex > 0) {
+        state.planIndex--;
+        renderPlans();
+      }
+      e.preventDefault();
+      break;
+    case 'o':
+      openIssue();
+      e.preventDefault();
+      break;
+  }
+}
+
+function focusPanel(panelId) {
+  state.focusedPanel = panelId;
+  document.getElementById(panelId)?.focus();
+}
+
+function focusNextPanel() {
+  const panels = ['project-list', 'worktree-table', 'details-panel'];
+  const idx = panels.indexOf(state.focusedPanel);
+  const next = panels[(idx + 1) % panels.length];
+  focusPanel(next);
+}
+
+function focusPrevPanel() {
+  const panels = ['project-list', 'worktree-table', 'details-panel'];
+  const idx = panels.indexOf(state.focusedPanel);
+  const prev = panels[(idx - 1 + panels.length) % panels.length];
+  focusPanel(prev);
+}
+
+function navigateDown() {
+  if (state.focusedPanel === 'project-list') {
+    if (state.projectIndex < state.projects.length - 1) {
+      state.projectIndex++;
+      selectProject(state.projects[state.projectIndex].name);
+    }
+  } else if (state.focusedPanel === 'worktree-table') {
+    const filtered = state.worktrees.filter(w => w.repo === state.selectedProject);
+    if (state.worktreeIndex < filtered.length - 1) {
+      selectWorktree(state.worktreeIndex + 1);
+    }
+  }
+}
+
+function navigateUp() {
+  if (state.focusedPanel === 'project-list') {
+    if (state.projectIndex > 0) {
+      state.projectIndex--;
+      selectProject(state.projects[state.projectIndex].name);
+    }
+  } else if (state.focusedPanel === 'worktree-table') {
+    if (state.worktreeIndex > 0) {
+      selectWorktree(state.worktreeIndex - 1);
+    }
+  }
+}
+
+function handleEnter() {
+  if (state.focusedPanel === 'project-list' && state.projects[state.projectIndex]) {
+    selectProject(state.projects[state.projectIndex].name);
+    focusPanel('worktree-table');
+  }
+}
+
+// Click handlers
+function setupClickHandlers() {
+  els.projectList.addEventListener('click', (e) => {
+    const item = e.target.closest('.list-item');
+    if (item) {
+      selectProject(item.dataset.project);
+      focusPanel('project-list');
+    }
+  });
+
+  els.worktreeRows.addEventListener('click', (e) => {
+    const row = e.target.closest('.table-row');
+    if (row) {
+      selectWorktree(parseInt(row.dataset.index));
+      focusPanel('worktree-table');
+    }
+  });
+
+  els.plansList.addEventListener('click', (e) => {
+    const item = e.target.closest('.list-item');
+    if (item) {
+      state.planIndex = parseInt(item.dataset.index);
+      renderPlans();
+    }
+  });
+
+  // Modal backdrop clicks
+  els.helpModal.addEventListener('click', (e) => {
+    if (e.target === els.helpModal) closeHelp();
+  });
+
+  els.plansModal.addEventListener('click', (e) => {
+    if (e.target === els.plansModal) closePlans();
+  });
+}
+
+// Modals
+function openHelp() {
+  els.helpModal.classList.remove('hidden');
+}
+
+function closeHelp() {
+  els.helpModal.classList.add('hidden');
+}
+
+function openPlans() {
+  loadPlans().then(() => {
+    els.plansModal.classList.remove('hidden');
+    els.plansList.focus();
+  });
+}
+
+function closePlans() {
+  els.plansModal.classList.add('hidden');
+}
+
+// Actions
+function openPR() {
+  if (!state.selectedWorktree || !state.selectedWorktree.prState) {
+    showNotification('No PR for this worktree');
+    return;
+  }
+
+  // Construct GitHub PR URL (assumes joshribakoff org)
+  const { repo, branch } = state.selectedWorktree;
+  const url = `https://github.com/joshribakoff/${repo}/pulls?q=head:${encodeURIComponent(branch)}`;
+  window.open(url, '_blank');
+}
+
+function openIssue() {
+  if (state.planIndex >= state.plans.length) return;
+
+  const plan = state.plans[state.planIndex];
+  if (!plan.issue) {
+    showNotification('No issue for this plan');
+    return;
+  }
+
+  const url = `https://github.com/joshribakoff/${plan.project}/issues/${plan.issue}`;
+  window.open(url, '_blank');
+}
+
+// Server-Sent Events
+function connectSSE() {
+  if (state.evtSource) {
+    state.evtSource.close();
+  }
+
+  setStatus('connecting');
+
+  state.evtSource = new EventSource(API_BASE + '/api/events');
+
+  state.evtSource.addEventListener('connected', () => {
+    setStatus('ok');
+  });
+
+  state.evtSource.addEventListener('update', (e) => {
+    try {
+      const data = JSON.parse(e.data);
+      if (data.type === 'health' || data.type === 'worktrees') {
+        refresh();
+      }
+    } catch (err) {
+      console.error('SSE parse error:', err);
+    }
+  });
+
+  state.evtSource.onerror = () => {
+    setStatus('error');
+    // Reconnect after delay
+    setTimeout(connectSSE, 5000);
+  };
+}
+
+function setStatus(status) {
+  els.statusIndicator.className = `status-${status}`;
+  els.statusIndicator.title = status === 'ok' ? 'Connected' :
+                              status === 'error' ? 'Disconnected' : 'Connecting...';
+}
+
+// Utilities
+function escapeHtml(str) {
+  if (!str) return '';
+  return str.replace(/[&<>"']/g, (c) => ({
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;',
+  }[c]));
+}
+
+function showNotification(msg) {
+  // Simple notification - could be enhanced
+  console.log('Notification:', msg);
+}
+
+function showError(msg) {
+  console.error('Error:', msg);
+  setStatus('error');
+}

--- a/web/index.html
+++ b/web/index.html
@@ -47,6 +47,7 @@
     <span><kbd>r</kbd>efresh</span>
     <span><kbd>o</kbd>pen PR</span>
     <span><kbd>p</kbd>lans</span>
+    <span><kbd>/</kbd> search</span>
     <span><kbd>?</kbd> help</span>
     <span class="footer-spacer"></span>
     <span id="status-indicator" class="status-ok" title="Connected"></span>
@@ -72,6 +73,7 @@
         <div class="binding"><kbd>r</kbd> Refresh data</div>
         <div class="binding"><kbd>o</kbd> Open PR in browser</div>
         <div class="binding"><kbd>p</kbd> View plans</div>
+        <div class="binding"><kbd>/</kbd> or <kbd>Ctrl+K</kbd> Command palette</div>
         <div class="binding"><kbd>?</kbd> Show this help</div>
         <div class="binding"><kbd>Esc</kbd> Close modal</div>
       </div>
@@ -83,6 +85,14 @@
     <div class="modal-content modal-wide">
       <h2>Plans <span class="modal-hint">(press o to open issue, Esc to close)</span></h2>
       <div id="plans-list" class="list" tabindex="0"></div>
+    </div>
+  </div>
+
+  <!-- Command Palette Modal -->
+  <div id="command-palette" class="modal hidden">
+    <div class="modal-content command-palette-content">
+      <input type="text" id="palette-input" placeholder="Search projects, worktrees, plans..." autocomplete="off">
+      <div id="palette-results" class="palette-results"></div>
     </div>
   </div>
 

--- a/web/index.html
+++ b/web/index.html
@@ -28,10 +28,10 @@
       <div class="panel-header">[1] Worktrees</div>
       <div id="worktree-table" class="table" tabindex="0">
         <div class="table-header">
-          <span class="col-folder">Folder</span>
-          <span class="col-branch">Branch</span>
-          <span class="col-status">Status</span>
-          <span class="col-pr">PR</span>
+          <span class="col-folder sortable" data-sort="folder">Folder</span>
+          <span class="col-branch sortable" data-sort="branch">Branch</span>
+          <span class="col-status sortable" data-sort="status">Status</span>
+          <span class="col-pr sortable" data-sort="pr">PR</span>
         </div>
         <div id="worktree-rows" class="table-body"></div>
       </div>

--- a/web/index.html
+++ b/web/index.html
@@ -7,11 +7,6 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <header id="title-bar">
-    <span class="anchor-icon">&#x2693;</span> Bearing
-    <span id="status-indicator" class="status-ok" title="Connected"></span>
-  </header>
-
   <nav class="tab-bar">
     <button class="tab active" data-view="worktrees">Worktrees</button>
     <button class="tab" data-view="issues">Issues</button>
@@ -53,6 +48,8 @@
     <span><kbd>o</kbd>pen PR</span>
     <span><kbd>p</kbd>lans</span>
     <span><kbd>?</kbd> help</span>
+    <span class="footer-spacer"></span>
+    <span id="status-indicator" class="status-ok" title="Connected"></span>
   </footer>
 
   <!-- Help Modal -->

--- a/web/index.html
+++ b/web/index.html
@@ -12,6 +12,12 @@
     <span id="status-indicator" class="status-ok" title="Connected"></span>
   </header>
 
+  <nav class="tab-bar">
+    <button class="tab active" data-view="worktrees">Worktrees</button>
+    <button class="tab" data-view="issues">Issues</button>
+    <button class="tab" data-view="prs">PRs</button>
+  </nav>
+
   <main id="main-container">
     <aside id="projects-panel" class="panel">
       <div class="panel-header">[0] Projects</div>
@@ -40,9 +46,9 @@
   </section>
 
   <footer id="footer-bar">
-    <span><kbd>0</kbd>-<kbd>2</kbd> panels</span>
+    <span><kbd>1</kbd>-<kbd>3</kbd> views</span>
+    <span><kbd>Tab</kbd> cycle</span>
     <span><kbd>j/k</kbd> nav</span>
-    <span><kbd>n</kbd>ew</span>
     <span><kbd>r</kbd>efresh</span>
     <span><kbd>o</kbd>pen PR</span>
     <span><kbd>p</kbd>lans</span>
@@ -55,14 +61,14 @@
       <h2>Bearing Dashboard - Keybindings</h2>
       <div class="keybindings">
         <h3>Navigation</h3>
-        <div class="binding"><kbd>0</kbd> Focus projects panel</div>
-        <div class="binding"><kbd>1</kbd> Focus worktrees panel</div>
-        <div class="binding"><kbd>2</kbd> Focus details panel</div>
+        <div class="binding"><kbd>1</kbd> Worktrees view</div>
+        <div class="binding"><kbd>2</kbd> Issues view</div>
+        <div class="binding"><kbd>3</kbd> PRs view</div>
         <div class="binding"><kbd>h</kbd> / <kbd>←</kbd> Focus left panel</div>
         <div class="binding"><kbd>l</kbd> / <kbd>→</kbd> Focus right panel</div>
         <div class="binding"><kbd>j</kbd> / <kbd>↓</kbd> Move down</div>
         <div class="binding"><kbd>k</kbd> / <kbd>↑</kbd> Move up</div>
-        <div class="binding"><kbd>Tab</kbd> Next panel</div>
+        <div class="binding"><kbd>Tab</kbd> Cycle views</div>
         <div class="binding"><kbd>Enter</kbd> Select item</div>
 
         <h3>Actions</h3>

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Bearing Dashboard</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header id="title-bar">
+    <span class="anchor-icon">&#x2693;</span> Bearing
+    <span id="status-indicator" class="status-ok" title="Connected"></span>
+  </header>
+
+  <main id="main-container">
+    <aside id="projects-panel" class="panel">
+      <div class="panel-header">[0] Projects</div>
+      <ul id="project-list" class="list" tabindex="0"></ul>
+    </aside>
+
+    <section id="worktrees-panel" class="panel">
+      <div class="panel-header">[1] Worktrees</div>
+      <div id="worktree-table" class="table" tabindex="0">
+        <div class="table-header">
+          <span class="col-folder">Folder</span>
+          <span class="col-branch">Branch</span>
+          <span class="col-status">Status</span>
+          <span class="col-pr">PR</span>
+        </div>
+        <div id="worktree-rows" class="table-body"></div>
+      </div>
+    </section>
+  </main>
+
+  <section id="details-section">
+    <div class="panel-header details-header">[2] Details</div>
+    <div id="details-panel" class="panel" tabindex="0">
+      <div id="details-content">Select a worktree to view details</div>
+    </div>
+  </section>
+
+  <footer id="footer-bar">
+    <span><kbd>0</kbd>-<kbd>2</kbd> panels</span>
+    <span><kbd>j/k</kbd> nav</span>
+    <span><kbd>n</kbd>ew</span>
+    <span><kbd>r</kbd>efresh</span>
+    <span><kbd>o</kbd>pen PR</span>
+    <span><kbd>p</kbd>lans</span>
+    <span><kbd>?</kbd> help</span>
+  </footer>
+
+  <!-- Help Modal -->
+  <div id="help-modal" class="modal hidden">
+    <div class="modal-content">
+      <h2>Bearing Dashboard - Keybindings</h2>
+      <div class="keybindings">
+        <h3>Navigation</h3>
+        <div class="binding"><kbd>0</kbd> Focus projects panel</div>
+        <div class="binding"><kbd>1</kbd> Focus worktrees panel</div>
+        <div class="binding"><kbd>2</kbd> Focus details panel</div>
+        <div class="binding"><kbd>h</kbd> / <kbd>←</kbd> Focus left panel</div>
+        <div class="binding"><kbd>l</kbd> / <kbd>→</kbd> Focus right panel</div>
+        <div class="binding"><kbd>j</kbd> / <kbd>↓</kbd> Move down</div>
+        <div class="binding"><kbd>k</kbd> / <kbd>↑</kbd> Move up</div>
+        <div class="binding"><kbd>Tab</kbd> Next panel</div>
+        <div class="binding"><kbd>Enter</kbd> Select item</div>
+
+        <h3>Actions</h3>
+        <div class="binding"><kbd>r</kbd> Refresh data</div>
+        <div class="binding"><kbd>o</kbd> Open PR in browser</div>
+        <div class="binding"><kbd>p</kbd> View plans</div>
+        <div class="binding"><kbd>?</kbd> Show this help</div>
+        <div class="binding"><kbd>Esc</kbd> Close modal</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Plans Modal -->
+  <div id="plans-modal" class="modal hidden">
+    <div class="modal-content modal-wide">
+      <h2>Plans <span class="modal-hint">(press o to open issue, Esc to close)</span></h2>
+      <div id="plans-list" class="list" tabindex="0"></div>
+    </div>
+  </div>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/web/lib.js
+++ b/web/lib.js
@@ -1,0 +1,93 @@
+// Bearing Web Dashboard - Pure functions (testable)
+// These are extracted from app.js for unit testing
+
+function escapeHtml(str) {
+  if (!str) return '';
+  return str.replace(/[&<>"']/g, (c) => ({
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;',
+  }[c]));
+}
+
+function sortWorktrees(worktrees, sortColumn, sortDirection) {
+  const sorted = [...worktrees];
+  const dir = sortDirection === 'asc' ? 1 : -1;
+
+  if (sortColumn === 'default') {
+    // Default: PR state (OPEN first), then dirty, then folder
+    sorted.sort((a, b) => {
+      const prOrder = { OPEN: 0, DRAFT: 1, MERGED: 2, CLOSED: 3 };
+      const aPr = prOrder[a.prState] ?? 4;
+      const bPr = prOrder[b.prState] ?? 4;
+      if (aPr !== bPr) return (aPr - bPr) * dir;
+      if (a.dirty !== b.dirty) return (b.dirty - a.dirty) * dir;
+      return a.folder.localeCompare(b.folder) * dir;
+    });
+  } else if (sortColumn === 'folder') {
+    sorted.sort((a, b) => a.folder.localeCompare(b.folder) * dir);
+  } else if (sortColumn === 'branch') {
+    sorted.sort((a, b) => a.branch.localeCompare(b.branch) * dir);
+  } else if (sortColumn === 'status') {
+    sorted.sort((a, b) => {
+      // dirty first, then unpushed, then clean
+      const aScore = a.dirty ? 0 : (a.unpushed > 0 ? 1 : 2);
+      const bScore = b.dirty ? 0 : (b.unpushed > 0 ? 1 : 2);
+      return (aScore - bScore) * dir;
+    });
+  } else if (sortColumn === 'pr') {
+    const prOrder = { OPEN: 0, DRAFT: 1, MERGED: 2, CLOSED: 3 };
+    sorted.sort((a, b) => {
+      const aPr = prOrder[a.prState] ?? 4;
+      const bPr = prOrder[b.prState] ?? 4;
+      return (aPr - bPr) * dir;
+    });
+  }
+
+  return sorted;
+}
+
+function createState() {
+  return {
+    selectedProject: null,
+    worktreeIndex: 0,
+    sortColumn: 'default',
+    sortDirection: 'asc',
+    currentView: 'worktrees',
+  };
+}
+
+function saveState(state, storage) {
+  const persisted = {
+    selectedProject: state.selectedProject,
+    worktreeIndex: state.worktreeIndex,
+    sortColumn: state.sortColumn,
+    sortDirection: state.sortDirection,
+    currentView: state.currentView,
+  };
+  storage.setItem('bearing-state', JSON.stringify(persisted));
+}
+
+function loadState(state, storage) {
+  try {
+    const saved = storage.getItem('bearing-state');
+    if (saved) {
+      const persisted = JSON.parse(saved);
+      state.selectedProject = persisted.selectedProject || null;
+      state.worktreeIndex = persisted.worktreeIndex || 0;
+      state.sortColumn = persisted.sortColumn || 'default';
+      state.sortDirection = persisted.sortDirection || 'asc';
+      state.currentView = persisted.currentView || 'worktrees';
+    }
+  } catch (e) {
+    // Silently fail on parse errors
+  }
+  return state;
+}
+
+// Export for Node.js testing
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { escapeHtml, sortWorktrees, createState, saveState, loadState };
+}

--- a/web/package.json
+++ b/web/package.json
@@ -4,8 +4,11 @@
   "private": true,
   "scripts": {
     "test": "playwright test",
+    "test:unit": "node tests/unit.test.js",
     "test:headed": "playwright test --headed",
     "test:debug": "playwright test --debug",
+    "test:visual": "playwright test tests/visual/",
+    "test:visual:update": "playwright test tests/visual/ --update-snapshots",
     "screenshot": "node scripts/generate_screenshots.js"
   },
   "devDependencies": {

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "bearing-web-dashboard",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "test": "playwright test",
+    "test:headed": "playwright test --headed",
+    "test:debug": "playwright test --debug",
+    "screenshot": "node scripts/generate_screenshots.js"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.40.0",
+    "playwright": "^1.40.0"
+  }
+}

--- a/web/playwright.config.js
+++ b/web/playwright.config.js
@@ -1,0 +1,28 @@
+// @ts-check
+const { defineConfig, devices } = require('@playwright/test');
+
+module.exports = defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    baseURL: 'http://localhost:8080',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'cd .. && go run ./cmd/bearing daemon start --foreground --port 8080',
+    url: 'http://localhost:8080',
+    reuseExistingServer: !process.env.CI,
+    timeout: 30000,
+  },
+});

--- a/web/scripts/generate_screenshots.js
+++ b/web/scripts/generate_screenshots.js
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+
+/**
+ * Screenshot generation script for the Bearing web dashboard.
+ * Captures screenshots for documentation, matching TUI screenshot scenarios.
+ */
+
+const { chromium } = require('playwright');
+const path = require('path');
+const fs = require('fs');
+
+const OUTPUT_DIR = path.join(__dirname, '../../docs/public/images');
+const BASE_URL = process.env.BASE_URL || 'http://localhost:8080';
+
+// Screenshot scenarios matching TUI
+const scenarios = [
+  {
+    name: 'web-dashboard-worktrees',
+    description: 'Worktrees view showing all worktrees',
+    setup: async (page) => {
+      await page.keyboard.press('w');
+    },
+  },
+  {
+    name: 'web-dashboard-projects',
+    description: 'Projects view showing project list',
+    setup: async (page) => {
+      await page.keyboard.press('p');
+    },
+  },
+  {
+    name: 'web-dashboard-plans',
+    description: 'Plans view showing all plans',
+    setup: async (page) => {
+      await page.keyboard.press('l');
+    },
+  },
+  {
+    name: 'web-dashboard-prs',
+    description: 'PRs view showing pull requests',
+    setup: async (page) => {
+      await page.keyboard.press('r');
+    },
+  },
+  {
+    name: 'web-dashboard-help',
+    description: 'Help modal showing keyboard shortcuts',
+    setup: async (page) => {
+      await page.keyboard.press('?');
+    },
+  },
+];
+
+async function generateScreenshots() {
+  console.log('Starting screenshot generation...');
+  console.log(`Output directory: ${OUTPUT_DIR}`);
+  console.log(`Base URL: ${BASE_URL}`);
+
+  // Ensure output directory exists
+  if (!fs.existsSync(OUTPUT_DIR)) {
+    fs.mkdirSync(OUTPUT_DIR, { recursive: true });
+  }
+
+  const browser = await chromium.launch();
+  const context = await browser.newContext({
+    viewport: { width: 1280, height: 720 },
+    deviceScaleFactor: 2, // Retina
+  });
+  const page = await context.newPage();
+
+  try {
+    // Navigate to dashboard
+    console.log('Loading dashboard...');
+    await page.goto(BASE_URL);
+    await page.waitForLoadState('networkidle');
+
+    for (const scenario of scenarios) {
+      console.log(`Capturing: ${scenario.name}`);
+
+      // Reset to default state
+      await page.goto(BASE_URL);
+      await page.waitForLoadState('networkidle');
+      await page.waitForTimeout(500);
+
+      // Run setup function
+      if (scenario.setup) {
+        await scenario.setup(page);
+        await page.waitForTimeout(300);
+      }
+
+      // Capture screenshot
+      const filename = `${scenario.name}.png`;
+      const filepath = path.join(OUTPUT_DIR, filename);
+
+      await page.screenshot({
+        path: filepath,
+        fullPage: false,
+      });
+
+      console.log(`  Saved: ${filename}`);
+    }
+
+    console.log('\nAll screenshots generated successfully!');
+    console.log(`Files saved to: ${OUTPUT_DIR}`);
+
+  } catch (error) {
+    console.error('Error generating screenshots:', error);
+    process.exit(1);
+  } finally {
+    await browser.close();
+  }
+}
+
+// Check if server is available
+async function checkServer() {
+  const { chromium } = require('playwright');
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+
+  try {
+    const response = await page.goto(BASE_URL, { timeout: 5000 });
+    await browser.close();
+    return response && response.ok();
+  } catch {
+    await browser.close();
+    return false;
+  }
+}
+
+async function main() {
+  console.log('Bearing Web Dashboard Screenshot Generator\n');
+
+  // Check if server is running
+  console.log('Checking if server is running...');
+  const serverAvailable = await checkServer();
+
+  if (!serverAvailable) {
+    console.error(`Error: Server not available at ${BASE_URL}`);
+    console.error('Please start the daemon with: go run ./cmd/bearing daemon start --port 8080');
+    process.exit(1);
+  }
+
+  console.log('Server is available.\n');
+  await generateScreenshots();
+}
+
+main();

--- a/web/style.css
+++ b/web/style.css
@@ -207,6 +207,7 @@ body {
 .table-header .sortable {
   cursor: pointer;
   user-select: none;
+  -webkit-user-select: none;
 }
 
 .table-header .sortable:hover {
@@ -214,16 +215,26 @@ body {
 }
 
 .table-header .sortable::after {
-  content: '';
+  content: '⇅';
   margin-left: 4px;
+  opacity: 0.3;
+  font-size: 10px;
+}
+
+.table-header .sortable:hover::after {
+  opacity: 0.6;
 }
 
 .table-header .sortable.sort-asc::after {
-  content: '\25B2';
+  content: '▲';
+  opacity: 1;
+  color: var(--accent-cyan);
 }
 
 .table-header .sortable.sort-desc::after {
-  content: '\25BC';
+  content: '▼';
+  opacity: 1;
+  color: var(--accent-cyan);
 }
 
 .table-body {
@@ -456,4 +467,84 @@ kbd {
 
 ::-webkit-scrollbar-thumb:hover {
   background: var(--text-dim);
+}
+
+/* Command Palette */
+#command-palette {
+  align-items: flex-start;
+  padding-top: 15vh;
+}
+
+.command-palette-content {
+  width: 500px;
+  max-width: 90vw;
+  padding: 0;
+  overflow: hidden;
+}
+
+#palette-input {
+  width: 100%;
+  background: var(--bg-surface);
+  border: none;
+  border-bottom: 1px solid var(--border);
+  color: var(--text);
+  font-family: inherit;
+  font-size: 14px;
+  padding: 12px 16px;
+  outline: none;
+}
+
+#palette-input::placeholder {
+  color: var(--text-dim);
+}
+
+.palette-results {
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+.palette-result {
+  padding: 8px 16px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.palette-result:hover,
+.palette-result.selected {
+  background: var(--bg-selection);
+}
+
+.palette-result.selected {
+  background: var(--bg-selection-focus);
+}
+
+.palette-type {
+  color: var(--text-dim);
+  font-size: 11px;
+  min-width: 70px;
+}
+
+.palette-text {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.palette-text .match {
+  color: var(--accent-cyan);
+  font-weight: bold;
+}
+
+.palette-meta {
+  color: var(--text-dim);
+  font-size: 11px;
+}
+
+.palette-empty {
+  padding: 16px;
+  color: var(--text-dim);
+  text-align: center;
 }

--- a/web/style.css
+++ b/web/style.css
@@ -61,6 +61,60 @@ body {
   font-size: 16px;
 }
 
+/* Tab Bar */
+.tab-bar {
+  background: #3c3f41;
+  display: flex;
+  gap: 0;
+  padding: 0 8px;
+  border-bottom: 1px solid var(--border);
+}
+
+.tab {
+  background: transparent;
+  border: none;
+  color: var(--text-dim);
+  padding: 8px 16px;
+  font-family: inherit;
+  font-size: 13px;
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.tab:hover {
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.tab.active {
+  color: var(--text-bright);
+  background: #4e5254;
+  border-bottom-color: var(--accent-cyan);
+}
+
+/* View containers */
+.view-container {
+  display: none;
+  flex: 1;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.view-container.active {
+  display: flex;
+}
+
+#placeholder-view {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  color: var(--text-dim);
+  font-size: 16px;
+  padding: 8px;
+}
+
 #status-indicator {
   width: 8px;
   height: 8px;

--- a/web/style.css
+++ b/web/style.css
@@ -43,24 +43,6 @@ body {
   overflow: hidden;
 }
 
-/* Title Bar */
-#title-bar {
-  background: var(--bg-surface);
-  color: var(--accent-cyan);
-  font-weight: bold;
-  text-align: center;
-  padding: 4px 8px;
-  border-bottom: 1px solid var(--border);
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  gap: 8px;
-}
-
-.anchor-icon {
-  font-size: 16px;
-}
-
 /* Tab Bar */
 .tab-bar {
   background: #3c3f41;
@@ -308,30 +290,35 @@ body {
 }
 
 #details-panel {
-  min-height: 100px;
-  max-height: 150px;
+  height: 80px;
   padding: 8px;
   border-radius: 0 0 4px 4px;
   outline: none;
+  overflow-y: auto;
 }
 
 #details-content {
   color: var(--text-dim);
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 4px 24px;
 }
 
 .detail-row {
   display: flex;
-  margin-bottom: 4px;
 }
 
 .detail-label {
   color: var(--accent-yellow);
-  width: 100px;
+  width: 70px;
   flex-shrink: 0;
 }
 
 .detail-value {
   color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 /* Footer */
@@ -343,6 +330,11 @@ body {
   display: flex;
   gap: 16px;
   font-size: 12px;
+  align-items: center;
+}
+
+.footer-spacer {
+  flex: 1;
 }
 
 kbd {

--- a/web/style.css
+++ b/web/style.css
@@ -222,6 +222,28 @@ body {
   border-bottom: 1px solid var(--border);
 }
 
+.table-header .sortable {
+  cursor: pointer;
+  user-select: none;
+}
+
+.table-header .sortable:hover {
+  color: var(--text-bright);
+}
+
+.table-header .sortable::after {
+  content: '';
+  margin-left: 4px;
+}
+
+.table-header .sortable.sort-asc::after {
+  content: '\25B2';
+}
+
+.table-header .sortable.sort-desc::after {
+  content: '\25BC';
+}
+
 .table-body {
   flex: 1;
   overflow-y: auto;

--- a/web/style.css
+++ b/web/style.css
@@ -1,0 +1,391 @@
+/* Bearing Web Dashboard - Darcula-inspired theme matching TUI */
+
+:root {
+  /* Darcula palette */
+  --bg: #1e1e1e;
+  --bg-panel: #252526;
+  --bg-surface: #2d2d2d;
+  --bg-highlight: #37373d;
+  --bg-selection: #264f78;
+  --bg-selection-focus: #2d5a8a;
+
+  --border: #3c3c3c;
+  --border-focus: #007acc;
+  --border-dim: #2d2d2d;
+
+  --text: #d4d4d4;
+  --text-dim: #808080;
+  --text-bright: #ffffff;
+
+  --accent-orange: #ce9178;
+  --accent-yellow: #dcdcaa;
+  --accent-green: #6a9955;
+  --accent-blue: #569cd6;
+  --accent-purple: #c586c0;
+  --accent-cyan: #4ec9b0;
+  --accent-red: #f44747;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'SF Mono', 'Menlo', 'Monaco', 'Consolas', monospace;
+  font-size: 13px;
+  background: var(--bg);
+  color: var(--text);
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+/* Title Bar */
+#title-bar {
+  background: var(--bg-surface);
+  color: var(--accent-cyan);
+  font-weight: bold;
+  text-align: center;
+  padding: 4px 8px;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
+}
+
+.anchor-icon {
+  font-size: 16px;
+}
+
+#status-indicator {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  margin-left: 8px;
+}
+
+.status-ok { background: var(--accent-green); }
+.status-error { background: var(--accent-red); }
+.status-connecting { background: var(--accent-yellow); }
+
+/* Main Container */
+#main-container {
+  display: flex;
+  flex: 1;
+  overflow: hidden;
+  padding: 8px;
+  gap: 8px;
+}
+
+/* Panels */
+.panel {
+  background: var(--bg-panel);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.panel:focus-within {
+  border-color: var(--border-focus);
+}
+
+.panel-header {
+  background: var(--bg-surface);
+  color: var(--accent-yellow);
+  font-weight: bold;
+  padding: 4px 8px;
+  border-bottom: 1px solid var(--border);
+}
+
+/* Projects Panel */
+#projects-panel {
+  width: 220px;
+  min-width: 180px;
+  flex-shrink: 0;
+}
+
+/* Worktrees Panel */
+#worktrees-panel {
+  flex: 1;
+}
+
+/* Lists */
+.list {
+  list-style: none;
+  overflow-y: auto;
+  flex: 1;
+  outline: none;
+}
+
+.list-item {
+  padding: 4px 8px;
+  cursor: pointer;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.list-item:hover {
+  background: var(--bg-highlight);
+}
+
+.list-item.selected {
+  background: var(--bg-selection);
+  color: var(--text-bright);
+}
+
+.list:focus .list-item.selected {
+  background: var(--bg-selection-focus);
+  font-weight: bold;
+}
+
+.project-count {
+  color: var(--text-dim);
+  font-size: 11px;
+}
+
+/* Table */
+.table {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  overflow: hidden;
+  outline: none;
+}
+
+.table-header {
+  display: flex;
+  background: var(--bg-surface);
+  color: var(--accent-blue);
+  font-weight: bold;
+  padding: 4px 8px;
+  border-bottom: 1px solid var(--border);
+}
+
+.table-body {
+  flex: 1;
+  overflow-y: auto;
+}
+
+.table-row {
+  display: flex;
+  padding: 4px 8px;
+  cursor: pointer;
+}
+
+.table-row:nth-child(odd) {
+  background: var(--bg-surface);
+}
+
+.table-row:nth-child(even) {
+  background: var(--bg-panel);
+}
+
+.table-row:hover {
+  background: var(--bg-highlight);
+}
+
+.table-row.selected {
+  background: var(--bg-selection);
+  color: var(--text-bright);
+}
+
+.table:focus .table-row.selected {
+  background: var(--bg-selection-focus);
+  font-weight: bold;
+}
+
+/* Table columns */
+.col-folder { flex: 2; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.col-branch { flex: 1.5; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.col-status { flex: 1; text-align: center; }
+.col-pr { flex: 0.8; text-align: center; }
+
+/* Status indicators */
+.status-dirty { color: var(--accent-yellow); }
+.status-clean { color: var(--accent-green); }
+.status-unpushed { color: var(--accent-orange); }
+
+.pr-open { color: var(--accent-green); }
+.pr-merged { color: var(--accent-purple); }
+.pr-draft { color: var(--text-dim); }
+.pr-closed { color: var(--accent-red); }
+
+.base-indicator { color: var(--accent-blue); font-size: 10px; margin-left: 4px; }
+
+/* Details Section */
+#details-section {
+  padding: 0 8px 8px;
+}
+
+.details-header {
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-bottom: none;
+  border-radius: 4px 4px 0 0;
+}
+
+#details-panel {
+  min-height: 100px;
+  max-height: 150px;
+  padding: 8px;
+  border-radius: 0 0 4px 4px;
+  outline: none;
+}
+
+#details-content {
+  color: var(--text-dim);
+}
+
+.detail-row {
+  display: flex;
+  margin-bottom: 4px;
+}
+
+.detail-label {
+  color: var(--accent-yellow);
+  width: 100px;
+  flex-shrink: 0;
+}
+
+.detail-value {
+  color: var(--text);
+}
+
+/* Footer */
+#footer-bar {
+  background: var(--bg-surface);
+  color: var(--text-dim);
+  padding: 4px 8px;
+  border-top: 1px solid var(--border);
+  display: flex;
+  gap: 16px;
+  font-size: 12px;
+}
+
+kbd {
+  color: var(--accent-yellow);
+  font-family: inherit;
+}
+
+/* Modals */
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+
+.modal.hidden {
+  display: none;
+}
+
+.modal-content {
+  background: var(--bg-panel);
+  border: 1px solid var(--accent-cyan);
+  border-radius: 4px;
+  padding: 16px;
+  max-width: 500px;
+  max-height: 80vh;
+  overflow-y: auto;
+}
+
+.modal-wide {
+  max-width: 700px;
+  width: 90%;
+}
+
+.modal-content h2 {
+  color: var(--accent-cyan);
+  margin-bottom: 16px;
+  font-size: 16px;
+}
+
+.modal-hint {
+  color: var(--text-dim);
+  font-size: 12px;
+  font-weight: normal;
+}
+
+.keybindings h3 {
+  color: var(--text);
+  margin: 12px 0 8px;
+  font-size: 13px;
+}
+
+.binding {
+  padding: 2px 0;
+  color: var(--text-dim);
+}
+
+.binding kbd {
+  display: inline-block;
+  min-width: 20px;
+  text-align: center;
+}
+
+/* Plans list in modal */
+#plans-list .list-item {
+  display: grid;
+  grid-template-columns: 20px 1fr 100px 80px;
+  gap: 8px;
+  align-items: center;
+}
+
+.plan-status {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+}
+
+.plan-status.active { background: var(--accent-green); }
+.plan-status.in_progress { background: var(--accent-yellow); }
+.plan-status.draft { background: var(--text-dim); }
+.plan-status.completed { background: var(--accent-blue); }
+
+.plan-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.plan-project {
+  color: var(--text-dim);
+  font-size: 11px;
+}
+
+.plan-issue {
+  color: var(--accent-cyan);
+  font-size: 11px;
+}
+
+/* Scrollbar styling */
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+::-webkit-scrollbar-track {
+  background: var(--bg-surface);
+}
+
+::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 4px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: var(--text-dim);
+}

--- a/web/tests/dashboard.spec.js
+++ b/web/tests/dashboard.spec.js
@@ -1,0 +1,173 @@
+// @ts-check
+const { test, expect } = require('@playwright/test');
+
+test.describe('Dashboard', () => {
+  test('page loads and renders header', async ({ page }) => {
+    await page.goto('/');
+
+    // Check page title
+    await expect(page).toHaveTitle(/Bearing/);
+
+    // Check header is present
+    const header = page.locator('header, .header, h1').first();
+    await expect(header).toBeVisible();
+  });
+
+  test('displays worktrees view by default', async ({ page }) => {
+    await page.goto('/');
+
+    // Wait for data to load
+    await page.waitForLoadState('networkidle');
+
+    // Check that worktrees section exists
+    const worktreesSection = page.locator('[data-view="worktrees"], .worktrees, .view-worktrees').first();
+    await expect(worktreesSection).toBeVisible({ timeout: 5000 });
+  });
+
+  test('renders project list', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    // Check for project items or empty state
+    const projects = page.locator('[data-project], .project-item, .project');
+    const count = await projects.count();
+
+    // Either has projects or shows empty state
+    if (count === 0) {
+      const emptyState = page.locator('.empty-state, .no-data');
+      await expect(emptyState).toBeVisible();
+    } else {
+      await expect(projects.first()).toBeVisible();
+    }
+  });
+});
+
+test.describe('Keyboard Navigation', () => {
+  test('w key switches to worktrees view', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    // Press 'w' key
+    await page.keyboard.press('w');
+
+    // Check worktrees view is active
+    const worktreesView = page.locator('[data-view="worktrees"].active, .view-worktrees.active, .worktrees-view');
+    await expect(worktreesView).toBeVisible({ timeout: 2000 });
+  });
+
+  test('p key switches to projects view', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    // Press 'p' key
+    await page.keyboard.press('p');
+
+    // Check projects view is active
+    const projectsView = page.locator('[data-view="projects"].active, .view-projects.active, .projects-view');
+    await expect(projectsView).toBeVisible({ timeout: 2000 });
+  });
+
+  test('j/k keys navigate list items', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    // Navigate down with 'j'
+    await page.keyboard.press('j');
+
+    // Check if selection moved (look for selected/focused class)
+    const selectedItem = page.locator('.selected, .focused, [aria-selected="true"]').first();
+    // May not have items if empty
+    const count = await selectedItem.count();
+    if (count > 0) {
+      await expect(selectedItem).toBeVisible();
+    }
+  });
+
+  test('? key shows help modal', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    // Press '?' key
+    await page.keyboard.press('?');
+
+    // Check help modal appears
+    const helpModal = page.locator('.modal, .help-modal, [role="dialog"]');
+    await expect(helpModal).toBeVisible({ timeout: 2000 });
+  });
+
+  test('Escape closes modal', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    // Open help modal
+    await page.keyboard.press('?');
+
+    // Wait for modal
+    const helpModal = page.locator('.modal, .help-modal, [role="dialog"]');
+    await expect(helpModal).toBeVisible({ timeout: 2000 });
+
+    // Close with Escape
+    await page.keyboard.press('Escape');
+
+    // Modal should be hidden
+    await expect(helpModal).toBeHidden({ timeout: 2000 });
+  });
+});
+
+test.describe('View Switching', () => {
+  test('can switch between all views', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    const views = ['w', 'p', 'l', 'r'];
+
+    for (const key of views) {
+      await page.keyboard.press(key);
+      // Small delay to let view switch
+      await page.waitForTimeout(100);
+    }
+
+    // Back to worktrees
+    await page.keyboard.press('w');
+    const worktreesView = page.locator('[data-view="worktrees"], .worktrees-view, .view-worktrees');
+    await expect(worktreesView.first()).toBeVisible({ timeout: 2000 });
+  });
+});
+
+test.describe('API Integration', () => {
+  test('fetches worktrees from API', async ({ page }) => {
+    // Intercept API call
+    const responsePromise = page.waitForResponse('**/api/worktrees**');
+
+    await page.goto('/');
+
+    const response = await responsePromise;
+    expect(response.status()).toBe(200);
+
+    const data = await response.json();
+    expect(Array.isArray(data)).toBe(true);
+  });
+
+  test('fetches projects from API', async ({ page }) => {
+    const responsePromise = page.waitForResponse('**/api/projects**');
+
+    await page.goto('/');
+    await page.keyboard.press('p'); // Switch to projects view
+
+    const response = await responsePromise;
+    expect(response.status()).toBe(200);
+
+    const data = await response.json();
+    expect(Array.isArray(data)).toBe(true);
+  });
+
+  test('status endpoint returns running', async ({ page }) => {
+    await page.goto('/');
+
+    const response = await page.request.get('/api/status');
+    expect(response.status()).toBe(200);
+
+    const data = await response.json();
+    expect(data.running).toBe(true);
+  });
+});

--- a/web/tests/e2e/keyboard.test.js
+++ b/web/tests/e2e/keyboard.test.js
@@ -1,0 +1,352 @@
+// @ts-check
+const { test, expect } = require('@playwright/test');
+
+const mockProjects = [
+  { name: 'bearing', count: 3 },
+  { name: 'sailkit', count: 2 },
+  { name: 'surfdeeper', count: 1 },
+];
+
+const mockWorktrees = [
+  { repo: 'bearing', folder: 'bearing', branch: 'main', base: true, dirty: false, unpushed: 0, prState: null },
+  { repo: 'bearing', folder: 'bearing-feature-x', branch: 'feature-x', base: false, dirty: true, unpushed: 2, prState: 'OPEN' },
+  { repo: 'bearing', folder: 'bearing-bugfix', branch: 'bugfix', base: false, dirty: false, unpushed: 0, prState: 'MERGED' },
+  { repo: 'sailkit', folder: 'sailkit', branch: 'main', base: true, dirty: false, unpushed: 0, prState: null },
+  { repo: 'sailkit', folder: 'sailkit-docs', branch: 'docs', base: false, dirty: true, unpushed: 1, prState: 'DRAFT' },
+];
+
+const mockPlans = [
+  { title: 'TUI improvements', project: 'bearing', status: 'in_progress', issue: 42 },
+  { title: 'Add compass component', project: 'sailkit', status: 'pending', issue: 15 },
+];
+
+test.describe('Keyboard - j/k Navigation', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/api/projects', route => route.fulfill({ json: mockProjects }));
+    await page.route('**/api/worktrees', route => route.fulfill({ json: mockWorktrees }));
+    await page.route('**/api/events', route => route.abort());
+
+    await page.goto('/');
+    await page.waitForSelector('#project-list .list-item');
+  });
+
+  test('j key moves selection down in project list', async ({ page }) => {
+    // Focus project list first (h key)
+    await page.keyboard.press('h');
+
+    // First project should be selected initially
+    await expect(page.locator('#project-list .list-item.selected')).toHaveAttribute('data-project', 'bearing');
+
+    // Press j to move down
+    await page.keyboard.press('j');
+
+    // Second project should now be selected
+    await expect(page.locator('#project-list .list-item.selected')).toHaveAttribute('data-project', 'sailkit');
+  });
+
+  test('k key moves selection up in project list', async ({ page }) => {
+    await page.keyboard.press('h');
+
+    // Move down twice
+    await page.keyboard.press('j');
+    await page.keyboard.press('j');
+    await expect(page.locator('#project-list .list-item.selected')).toHaveAttribute('data-project', 'surfdeeper');
+
+    // Move back up
+    await page.keyboard.press('k');
+    await expect(page.locator('#project-list .list-item.selected')).toHaveAttribute('data-project', 'sailkit');
+  });
+
+  test('j/k navigates worktree list when focused', async ({ page }) => {
+    // Focus worktree table (l key moves right)
+    await page.keyboard.press('l');
+
+    // First worktree should be selected
+    await expect(page.locator('#worktree-rows .table-row.selected')).toHaveAttribute('data-index', '0');
+
+    // Press j to move down
+    await page.keyboard.press('j');
+    await expect(page.locator('#worktree-rows .table-row.selected')).toHaveAttribute('data-index', '1');
+
+    // Press k to move back up
+    await page.keyboard.press('k');
+    await expect(page.locator('#worktree-rows .table-row.selected')).toHaveAttribute('data-index', '0');
+  });
+
+  test('j does not go past last item', async ({ page }) => {
+    await page.keyboard.press('h');
+
+    // Move to last project
+    await page.keyboard.press('j');
+    await page.keyboard.press('j');
+    await expect(page.locator('#project-list .list-item.selected')).toHaveAttribute('data-project', 'surfdeeper');
+
+    // Try to go further - should stay on last
+    await page.keyboard.press('j');
+    await expect(page.locator('#project-list .list-item.selected')).toHaveAttribute('data-project', 'surfdeeper');
+  });
+
+  test('k does not go past first item', async ({ page }) => {
+    await page.keyboard.press('h');
+
+    // Already at first, try to go up
+    await page.keyboard.press('k');
+    await expect(page.locator('#project-list .list-item.selected')).toHaveAttribute('data-project', 'bearing');
+  });
+
+  test('Arrow keys work same as j/k', async ({ page }) => {
+    await page.keyboard.press('h');
+
+    await page.keyboard.press('ArrowDown');
+    await expect(page.locator('#project-list .list-item.selected')).toHaveAttribute('data-project', 'sailkit');
+
+    await page.keyboard.press('ArrowUp');
+    await expect(page.locator('#project-list .list-item.selected')).toHaveAttribute('data-project', 'bearing');
+  });
+});
+
+test.describe('Keyboard - h/l Panel Focus', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/api/projects', route => route.fulfill({ json: mockProjects }));
+    await page.route('**/api/worktrees', route => route.fulfill({ json: mockWorktrees }));
+    await page.route('**/api/events', route => route.abort());
+
+    await page.goto('/');
+    await page.waitForSelector('#project-list .list-item');
+  });
+
+  test('h key focuses project list', async ({ page }) => {
+    await page.keyboard.press('h');
+
+    // j/k should now navigate projects, not worktrees
+    await page.keyboard.press('j');
+    await expect(page.locator('#project-list .list-item.selected')).toHaveAttribute('data-project', 'sailkit');
+  });
+
+  test('l key focuses worktree table', async ({ page }) => {
+    await page.keyboard.press('l');
+
+    // j/k should navigate worktrees
+    await page.keyboard.press('j');
+    await expect(page.locator('#worktree-rows .table-row.selected')).toHaveAttribute('data-index', '1');
+  });
+
+  test('Enter in project list moves focus to worktrees', async ({ page }) => {
+    await page.keyboard.press('h');
+
+    // Select a project with Enter
+    await page.keyboard.press('Enter');
+
+    // Focus should move to worktree table - test by navigating
+    await page.keyboard.press('j');
+    await expect(page.locator('#worktree-rows .table-row.selected')).toHaveAttribute('data-index', '1');
+  });
+
+  test('Arrow keys work for panel focus', async ({ page }) => {
+    await page.keyboard.press('ArrowLeft');
+
+    await page.keyboard.press('ArrowDown');
+    await expect(page.locator('#project-list .list-item.selected')).toHaveAttribute('data-project', 'sailkit');
+
+    await page.keyboard.press('ArrowRight');
+    await page.keyboard.press('ArrowDown');
+    await expect(page.locator('#worktree-rows .table-row.selected')).toHaveAttribute('data-index', '1');
+  });
+});
+
+test.describe('Keyboard - Number Keys for Views', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/api/projects', route => route.fulfill({ json: mockProjects }));
+    await page.route('**/api/worktrees', route => route.fulfill({ json: mockWorktrees }));
+    await page.route('**/api/events', route => route.abort());
+
+    await page.goto('/');
+  });
+
+  test('1 key switches to worktrees view', async ({ page }) => {
+    // First switch away
+    await page.keyboard.press('2');
+    await expect(page.locator('.tab[data-view="issues"]')).toHaveClass(/active/);
+
+    // Press 1 to go back
+    await page.keyboard.press('1');
+    await expect(page.locator('.tab[data-view="worktrees"]')).toHaveClass(/active/);
+    await expect(page.locator('#main-container')).toHaveCSS('display', 'flex');
+  });
+
+  test('2 key switches to issues view', async ({ page }) => {
+    await page.keyboard.press('2');
+
+    await expect(page.locator('.tab[data-view="issues"]')).toHaveClass(/active/);
+    await expect(page.locator('#main-container')).toHaveCSS('display', 'none');
+  });
+
+  test('3 key switches to PRs view', async ({ page }) => {
+    await page.keyboard.press('3');
+
+    await expect(page.locator('.tab[data-view="prs"]')).toHaveClass(/active/);
+    await expect(page.locator('#placeholder-view')).toContainText('Pull Requests');
+  });
+
+  test('number keys update localStorage', async ({ page }) => {
+    await page.keyboard.press('3');
+
+    const savedState = await page.evaluate(() => {
+      return JSON.parse(localStorage.getItem('bearing-state') || '{}');
+    });
+
+    expect(savedState.currentView).toBe('prs');
+  });
+});
+
+test.describe('Keyboard - Tab Cycling', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/api/projects', route => route.fulfill({ json: mockProjects }));
+    await page.route('**/api/worktrees', route => route.fulfill({ json: mockWorktrees }));
+    await page.route('**/api/events', route => route.abort());
+
+    await page.goto('/');
+  });
+
+  test('Tab key cycles through views', async ({ page }) => {
+    // Start on worktrees
+    await expect(page.locator('.tab[data-view="worktrees"]')).toHaveClass(/active/);
+
+    // Tab -> issues
+    await page.keyboard.press('Tab');
+    await expect(page.locator('.tab[data-view="issues"]')).toHaveClass(/active/);
+
+    // Tab -> prs
+    await page.keyboard.press('Tab');
+    await expect(page.locator('.tab[data-view="prs"]')).toHaveClass(/active/);
+
+    // Tab -> back to worktrees (cycle)
+    await page.keyboard.press('Tab');
+    await expect(page.locator('.tab[data-view="worktrees"]')).toHaveClass(/active/);
+  });
+
+  test('Tab cycling persists state', async ({ page }) => {
+    await page.keyboard.press('Tab');
+
+    const savedState = await page.evaluate(() => {
+      return JSON.parse(localStorage.getItem('bearing-state') || '{}');
+    });
+
+    expect(savedState.currentView).toBe('issues');
+  });
+});
+
+test.describe('Keyboard - Help Modal', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/api/projects', route => route.fulfill({ json: mockProjects }));
+    await page.route('**/api/worktrees', route => route.fulfill({ json: mockWorktrees }));
+    await page.route('**/api/events', route => route.abort());
+
+    await page.goto('/');
+  });
+
+  test('? key opens help modal', async ({ page }) => {
+    await page.keyboard.press('?');
+
+    await expect(page.locator('#help-modal')).not.toHaveClass(/hidden/);
+    await expect(page.locator('#help-modal')).toContainText('Keybindings');
+  });
+
+  test('Escape closes help modal', async ({ page }) => {
+    await page.keyboard.press('?');
+    await expect(page.locator('#help-modal')).not.toHaveClass(/hidden/);
+
+    await page.keyboard.press('Escape');
+    await expect(page.locator('#help-modal')).toHaveClass(/hidden/);
+  });
+
+  test('? key also closes help modal', async ({ page }) => {
+    await page.keyboard.press('?');
+    await expect(page.locator('#help-modal')).not.toHaveClass(/hidden/);
+
+    await page.keyboard.press('?');
+    await expect(page.locator('#help-modal')).toHaveClass(/hidden/);
+  });
+
+  test('other keys blocked when help modal open', async ({ page }) => {
+    await page.keyboard.press('?');
+
+    // Try to change view - should not work
+    await page.keyboard.press('2');
+    await expect(page.locator('.tab[data-view="worktrees"]')).toHaveClass(/active/);
+  });
+});
+
+test.describe('Keyboard - Plans Modal', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/api/projects', route => route.fulfill({ json: mockProjects }));
+    await page.route('**/api/worktrees', route => route.fulfill({ json: mockWorktrees }));
+    await page.route('**/api/plans', route => route.fulfill({ json: mockPlans }));
+    await page.route('**/api/events', route => route.abort());
+
+    await page.goto('/');
+  });
+
+  test('p key opens plans modal', async ({ page }) => {
+    await page.keyboard.press('p');
+
+    await expect(page.locator('#plans-modal')).not.toHaveClass(/hidden/);
+  });
+
+  test('j/k navigates plans in modal', async ({ page }) => {
+    await page.keyboard.press('p');
+    await page.waitForSelector('#plans-list .list-item');
+
+    // First plan selected
+    await expect(page.locator('#plans-list .list-item.selected')).toContainText('TUI improvements');
+
+    // Navigate down
+    await page.keyboard.press('j');
+    await expect(page.locator('#plans-list .list-item.selected')).toContainText('Add compass');
+
+    // Navigate back up
+    await page.keyboard.press('k');
+    await expect(page.locator('#plans-list .list-item.selected')).toContainText('TUI improvements');
+  });
+
+  test('Escape closes plans modal', async ({ page }) => {
+    await page.keyboard.press('p');
+    await expect(page.locator('#plans-modal')).not.toHaveClass(/hidden/);
+
+    await page.keyboard.press('Escape');
+    await expect(page.locator('#plans-modal')).toHaveClass(/hidden/);
+  });
+
+  test('p key also closes plans modal', async ({ page }) => {
+    await page.keyboard.press('p');
+    await expect(page.locator('#plans-modal')).not.toHaveClass(/hidden/);
+
+    await page.keyboard.press('p');
+    await expect(page.locator('#plans-modal')).toHaveClass(/hidden/);
+  });
+});
+
+test.describe('Keyboard - Refresh', () => {
+  test('r key triggers data refresh', async ({ page }) => {
+    let refreshCount = 0;
+    await page.route('**/api/projects', route => {
+      refreshCount++;
+      route.fulfill({ json: mockProjects });
+    });
+    await page.route('**/api/worktrees', route => route.fulfill({ json: mockWorktrees }));
+    await page.route('**/api/events', route => route.abort());
+
+    await page.goto('/');
+    await page.waitForSelector('#project-list .list-item');
+
+    const initialCount = refreshCount;
+
+    // Press r to refresh
+    await page.keyboard.press('r');
+
+    // Wait for API call
+    await page.waitForTimeout(100);
+
+    expect(refreshCount).toBeGreaterThan(initialCount);
+  });
+});

--- a/web/tests/e2e/navigation.test.js
+++ b/web/tests/e2e/navigation.test.js
@@ -1,0 +1,223 @@
+// @ts-check
+const { test, expect } = require('@playwright/test');
+
+// Mock data for tests
+const mockProjects = [
+  { name: 'bearing', count: 3 },
+  { name: 'sailkit', count: 2 },
+  { name: 'surfdeeper', count: 1 },
+];
+
+const mockWorktrees = [
+  { repo: 'bearing', folder: 'bearing', branch: 'main', base: true, dirty: false, unpushed: 0, prState: null },
+  { repo: 'bearing', folder: 'bearing-feature-x', branch: 'feature-x', base: false, dirty: true, unpushed: 2, prState: 'OPEN' },
+  { repo: 'bearing', folder: 'bearing-bugfix', branch: 'bugfix', base: false, dirty: false, unpushed: 0, prState: 'MERGED' },
+  { repo: 'sailkit', folder: 'sailkit', branch: 'main', base: true, dirty: false, unpushed: 0, prState: null },
+  { repo: 'sailkit', folder: 'sailkit-docs', branch: 'docs', base: false, dirty: true, unpushed: 1, prState: 'DRAFT' },
+  { repo: 'surfdeeper', folder: 'surfdeeper', branch: 'main', base: true, dirty: false, unpushed: 0, prState: null },
+];
+
+test.describe('Navigation - Project Selection', () => {
+  test.beforeEach(async ({ page }) => {
+    // Intercept API calls with mock data
+    await page.route('**/api/projects', route => {
+      route.fulfill({ json: mockProjects });
+    });
+    await page.route('**/api/worktrees', route => {
+      route.fulfill({ json: mockWorktrees });
+    });
+    await page.route('**/api/events', route => {
+      // SSE endpoint - just hang
+      route.abort();
+    });
+
+    await page.goto('/');
+    await page.waitForSelector('#project-list .list-item');
+  });
+
+  test('clicking a project selects it and updates worktree list', async ({ page }) => {
+    // Click sailkit project
+    await page.click('[data-project="sailkit"]');
+
+    // Verify project is selected
+    const selectedProject = page.locator('#project-list .list-item.selected');
+    await expect(selectedProject).toHaveAttribute('data-project', 'sailkit');
+
+    // Verify worktree list shows sailkit worktrees
+    const worktreeRows = page.locator('#worktree-rows .table-row');
+    await expect(worktreeRows).toHaveCount(2);
+
+    // First row should be sailkit (base)
+    await expect(worktreeRows.first()).toContainText('sailkit');
+  });
+
+  test('clicking a different project updates selection', async ({ page }) => {
+    // First select surfdeeper
+    await page.click('[data-project="surfdeeper"]');
+    await expect(page.locator('#project-list .list-item.selected')).toHaveAttribute('data-project', 'surfdeeper');
+
+    // Then select bearing
+    await page.click('[data-project="bearing"]');
+    await expect(page.locator('#project-list .list-item.selected')).toHaveAttribute('data-project', 'bearing');
+
+    // Verify worktree count for bearing
+    const worktreeRows = page.locator('#worktree-rows .table-row');
+    await expect(worktreeRows).toHaveCount(3);
+  });
+
+  test('project selection persists in localStorage', async ({ page }) => {
+    // Select sailkit
+    await page.click('[data-project="sailkit"]');
+
+    // Check localStorage
+    const savedState = await page.evaluate(() => {
+      return JSON.parse(localStorage.getItem('bearing-state') || '{}');
+    });
+
+    expect(savedState.selectedProject).toBe('sailkit');
+  });
+});
+
+test.describe('Navigation - Worktree Selection', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/api/projects', route => route.fulfill({ json: mockProjects }));
+    await page.route('**/api/worktrees', route => route.fulfill({ json: mockWorktrees }));
+    await page.route('**/api/events', route => route.abort());
+
+    await page.goto('/');
+    await page.waitForSelector('#worktree-rows .table-row');
+  });
+
+  test('clicking a worktree selects it and updates details panel', async ({ page }) => {
+    // Click second worktree row
+    await page.click('#worktree-rows .table-row:nth-child(2)');
+
+    // Verify row is selected
+    const selectedRow = page.locator('#worktree-rows .table-row.selected');
+    await expect(selectedRow).toHaveAttribute('data-index', '1');
+
+    // Verify details panel shows worktree info
+    const detailsContent = page.locator('#details-content');
+    await expect(detailsContent).toContainText('Folder:');
+  });
+
+  test('worktree selection updates details with health info', async ({ page }) => {
+    // Select a dirty worktree with unpushed commits
+    await page.click('[data-project="bearing"]');
+    await page.waitForSelector('#worktree-rows .table-row');
+
+    // Find and click the dirty worktree
+    const dirtyRow = page.locator('#worktree-rows .table-row', { hasText: 'feature-x' });
+    await dirtyRow.click();
+
+    // Check details panel shows health info
+    const detailsContent = page.locator('#details-content');
+    await expect(detailsContent).toContainText('Health:');
+    await expect(detailsContent).toContainText('Uncommitted');
+  });
+
+  test('worktree index persists in localStorage', async ({ page }) => {
+    // Click third row
+    await page.click('#worktree-rows .table-row:nth-child(3)');
+
+    const savedState = await page.evaluate(() => {
+      return JSON.parse(localStorage.getItem('bearing-state') || '{}');
+    });
+
+    expect(savedState.worktreeIndex).toBe(2);
+  });
+});
+
+test.describe('Navigation - Tab Views', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/api/projects', route => route.fulfill({ json: mockProjects }));
+    await page.route('**/api/worktrees', route => route.fulfill({ json: mockWorktrees }));
+    await page.route('**/api/events', route => route.abort());
+
+    await page.goto('/');
+  });
+
+  test('clicking tab changes active view', async ({ page }) => {
+    // Click Issues tab
+    await page.click('.tab[data-view="issues"]');
+
+    // Verify tab is active
+    await expect(page.locator('.tab[data-view="issues"]')).toHaveClass(/active/);
+    await expect(page.locator('.tab[data-view="worktrees"]')).not.toHaveClass(/active/);
+
+    // Main container should be hidden
+    await expect(page.locator('#main-container')).toHaveCSS('display', 'none');
+  });
+
+  test('clicking PRs tab shows placeholder', async ({ page }) => {
+    await page.click('.tab[data-view="prs"]');
+
+    // PRs tab should be active
+    await expect(page.locator('.tab[data-view="prs"]')).toHaveClass(/active/);
+
+    // Placeholder should be visible
+    const placeholder = page.locator('#placeholder-view');
+    await expect(placeholder).toBeVisible();
+    await expect(placeholder).toContainText('Pull Requests');
+  });
+
+  test('switching back to worktrees shows main content', async ({ page }) => {
+    // Go to issues
+    await page.click('.tab[data-view="issues"]');
+    await expect(page.locator('#main-container')).toHaveCSS('display', 'none');
+
+    // Go back to worktrees
+    await page.click('.tab[data-view="worktrees"]');
+    await expect(page.locator('#main-container')).toHaveCSS('display', 'flex');
+  });
+
+  test('current view persists in localStorage', async ({ page }) => {
+    await page.click('.tab[data-view="prs"]');
+
+    const savedState = await page.evaluate(() => {
+      return JSON.parse(localStorage.getItem('bearing-state') || '{}');
+    });
+
+    expect(savedState.currentView).toBe('prs');
+  });
+});
+
+test.describe('Navigation - Persistence on Reload', () => {
+  test('selected project survives page reload', async ({ page }) => {
+    await page.route('**/api/projects', route => route.fulfill({ json: mockProjects }));
+    await page.route('**/api/worktrees', route => route.fulfill({ json: mockWorktrees }));
+    await page.route('**/api/events', route => route.abort());
+
+    await page.goto('/');
+    await page.waitForSelector('#project-list .list-item');
+
+    // Select sailkit
+    await page.click('[data-project="sailkit"]');
+    await expect(page.locator('#project-list .list-item.selected')).toHaveAttribute('data-project', 'sailkit');
+
+    // Reload page
+    await page.reload();
+    await page.waitForSelector('#project-list .list-item');
+
+    // Verify sailkit is still selected
+    await expect(page.locator('#project-list .list-item.selected')).toHaveAttribute('data-project', 'sailkit');
+  });
+
+  test('current view survives page reload', async ({ page }) => {
+    await page.route('**/api/projects', route => route.fulfill({ json: mockProjects }));
+    await page.route('**/api/worktrees', route => route.fulfill({ json: mockWorktrees }));
+    await page.route('**/api/events', route => route.abort());
+
+    await page.goto('/');
+
+    // Switch to PRs view
+    await page.click('.tab[data-view="prs"]');
+    await expect(page.locator('.tab[data-view="prs"]')).toHaveClass(/active/);
+
+    // Reload
+    await page.reload();
+
+    // PRs should still be active
+    await expect(page.locator('.tab[data-view="prs"]')).toHaveClass(/active/);
+  });
+});

--- a/web/tests/e2e/sorting.test.js
+++ b/web/tests/e2e/sorting.test.js
@@ -1,0 +1,230 @@
+// @ts-check
+const { test, expect } = require('@playwright/test');
+
+const mockProjects = [
+  { name: 'bearing', count: 5 },
+];
+
+// Worktrees with varied data for sorting tests
+const mockWorktrees = [
+  { repo: 'bearing', folder: 'bearing', branch: 'main', base: true, dirty: false, unpushed: 0, prState: null },
+  { repo: 'bearing', folder: 'bearing-alpha', branch: 'feature-alpha', base: false, dirty: true, unpushed: 2, prState: 'OPEN' },
+  { repo: 'bearing', folder: 'bearing-zeta', branch: 'bugfix-zeta', base: false, dirty: false, unpushed: 0, prState: 'MERGED' },
+  { repo: 'bearing', folder: 'bearing-beta', branch: 'draft-beta', base: false, dirty: false, unpushed: 1, prState: 'DRAFT' },
+  { repo: 'bearing', folder: 'bearing-gamma', branch: 'wip-gamma', base: false, dirty: true, unpushed: 0, prState: 'CLOSED' },
+];
+
+test.describe('Sorting - Column Headers', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/api/projects', route => route.fulfill({ json: mockProjects }));
+    await page.route('**/api/worktrees', route => route.fulfill({ json: mockWorktrees }));
+    await page.route('**/api/events', route => route.abort());
+
+    await page.goto('/');
+    await page.waitForSelector('#worktree-rows .table-row');
+  });
+
+  test('clicking Folder header sorts by folder name', async ({ page }) => {
+    // Click folder header
+    await page.click('[data-sort="folder"]');
+
+    // Get folder names in order
+    const folders = await page.locator('#worktree-rows .table-row .col-folder').allTextContents();
+    const cleanFolders = folders.map(f => f.replace('BASE', '').trim());
+
+    // Should be alphabetically sorted (asc)
+    const sorted = [...cleanFolders].sort();
+    expect(cleanFolders).toEqual(sorted);
+
+    // Header should show sort indicator
+    await expect(page.locator('[data-sort="folder"]')).toHaveClass(/sort-asc/);
+  });
+
+  test('clicking same header toggles sort direction', async ({ page }) => {
+    // Click folder header twice
+    await page.click('[data-sort="folder"]');
+    await expect(page.locator('[data-sort="folder"]')).toHaveClass(/sort-asc/);
+
+    await page.click('[data-sort="folder"]');
+    await expect(page.locator('[data-sort="folder"]')).toHaveClass(/sort-desc/);
+
+    // Get folder names
+    const folders = await page.locator('#worktree-rows .table-row .col-folder').allTextContents();
+    const cleanFolders = folders.map(f => f.replace('BASE', '').trim());
+
+    // Should be reverse alphabetically sorted
+    const sorted = [...cleanFolders].sort().reverse();
+    expect(cleanFolders).toEqual(sorted);
+  });
+
+  test('clicking Branch header sorts by branch name', async ({ page }) => {
+    await page.click('[data-sort="branch"]');
+
+    const branches = await page.locator('#worktree-rows .table-row .col-branch').allTextContents();
+
+    // Should be alphabetically sorted
+    const sorted = [...branches].sort();
+    expect(branches).toEqual(sorted);
+
+    await expect(page.locator('[data-sort="branch"]')).toHaveClass(/sort-asc/);
+  });
+
+  test('clicking Status header sorts by status', async ({ page }) => {
+    await page.click('[data-sort="status"]');
+
+    // Verify header has sort indicator
+    await expect(page.locator('[data-sort="status"]')).toHaveClass(/sort-asc/);
+
+    // Status sort order: dirty first, then unpushed, then clean
+    const rows = page.locator('#worktree-rows .table-row');
+    const count = await rows.count();
+
+    // First rows should have dirty indicator (*)
+    const firstRowStatus = await rows.first().locator('.col-status').textContent();
+    expect(firstRowStatus).toContain('*');
+  });
+
+  test('clicking PR header sorts by PR state', async ({ page }) => {
+    await page.click('[data-sort="pr"]');
+
+    await expect(page.locator('[data-sort="pr"]')).toHaveClass(/sort-asc/);
+
+    // PR sort order: OPEN, DRAFT, MERGED, CLOSED, none
+    const prStates = await page.locator('#worktree-rows .table-row .col-pr').allTextContents();
+
+    // First should be OPEN
+    expect(prStates[0]).toContain('OPEN');
+  });
+
+  test('switching columns clears previous sort indicator', async ({ page }) => {
+    // Sort by folder
+    await page.click('[data-sort="folder"]');
+    await expect(page.locator('[data-sort="folder"]')).toHaveClass(/sort-asc/);
+
+    // Sort by branch
+    await page.click('[data-sort="branch"]');
+    await expect(page.locator('[data-sort="branch"]')).toHaveClass(/sort-asc/);
+    await expect(page.locator('[data-sort="folder"]')).not.toHaveClass(/sort-asc/);
+    await expect(page.locator('[data-sort="folder"]')).not.toHaveClass(/sort-desc/);
+  });
+});
+
+test.describe('Sorting - Persistence', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/api/projects', route => route.fulfill({ json: mockProjects }));
+    await page.route('**/api/worktrees', route => route.fulfill({ json: mockWorktrees }));
+    await page.route('**/api/events', route => route.abort());
+  });
+
+  test('sort column persists in localStorage', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector('#worktree-rows .table-row');
+
+    await page.click('[data-sort="branch"]');
+
+    const savedState = await page.evaluate(() => {
+      return JSON.parse(localStorage.getItem('bearing-state') || '{}');
+    });
+
+    expect(savedState.sortColumn).toBe('branch');
+    expect(savedState.sortDirection).toBe('asc');
+  });
+
+  test('sort direction persists in localStorage', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector('#worktree-rows .table-row');
+
+    await page.click('[data-sort="folder"]');
+    await page.click('[data-sort="folder"]'); // Toggle to desc
+
+    const savedState = await page.evaluate(() => {
+      return JSON.parse(localStorage.getItem('bearing-state') || '{}');
+    });
+
+    expect(savedState.sortColumn).toBe('folder');
+    expect(savedState.sortDirection).toBe('desc');
+  });
+
+  test('sort state survives page reload', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector('#worktree-rows .table-row');
+
+    // Sort by branch descending
+    await page.click('[data-sort="branch"]');
+    await page.click('[data-sort="branch"]');
+    await expect(page.locator('[data-sort="branch"]')).toHaveClass(/sort-desc/);
+
+    // Reload
+    await page.reload();
+    await page.waitForSelector('#worktree-rows .table-row');
+
+    // Branch should still have desc indicator
+    await expect(page.locator('[data-sort="branch"]')).toHaveClass(/sort-desc/);
+
+    // Verify data is still sorted
+    const branches = await page.locator('#worktree-rows .table-row .col-branch').allTextContents();
+    const sorted = [...branches].sort().reverse();
+    expect(branches).toEqual(sorted);
+  });
+});
+
+test.describe('Sorting - Selection Interaction', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/api/projects', route => route.fulfill({ json: mockProjects }));
+    await page.route('**/api/worktrees', route => route.fulfill({ json: mockWorktrees }));
+    await page.route('**/api/events', route => route.abort());
+
+    await page.goto('/');
+    await page.waitForSelector('#worktree-rows .table-row');
+  });
+
+  test('sorting preserves worktree index position', async ({ page }) => {
+    // Select second row
+    await page.click('#worktree-rows .table-row:nth-child(2)');
+    await expect(page.locator('#worktree-rows .table-row.selected')).toHaveAttribute('data-index', '1');
+
+    // Sort by folder
+    await page.click('[data-sort="folder"]');
+
+    // Selection should still be at index 1 (same position in list)
+    await expect(page.locator('#worktree-rows .table-row.selected')).toHaveAttribute('data-index', '1');
+  });
+
+  test('details panel updates after sorting', async ({ page }) => {
+    // Select first row
+    await page.click('#worktree-rows .table-row:first-child');
+    const detailsBefore = await page.locator('#details-content').textContent();
+
+    // Sort by branch - order changes
+    await page.click('[data-sort="branch"]');
+
+    // Details should reflect current selection
+    const detailsAfter = await page.locator('#details-content').textContent();
+    expect(detailsAfter).toContain('Folder:');
+  });
+});
+
+test.describe('Sorting - Default Order', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/api/projects', route => route.fulfill({ json: mockProjects }));
+    await page.route('**/api/worktrees', route => route.fulfill({ json: mockWorktrees }));
+    await page.route('**/api/events', route => route.abort());
+  });
+
+  test('default sort prioritizes OPEN PRs', async ({ page }) => {
+    // Clear localStorage to ensure default
+    await page.evaluate(() => localStorage.clear());
+
+    await page.goto('/');
+    await page.waitForSelector('#worktree-rows .table-row');
+
+    // First worktree with PR should be OPEN
+    const firstPR = await page.locator('#worktree-rows .table-row .col-pr span').first();
+    const text = await firstPR.textContent();
+
+    // OPEN should appear before MERGED, CLOSED
+    if (text) {
+      expect(['OPEN', '']).toContain(text.trim() || '');
+    }
+  });
+});

--- a/web/tests/unit.test.js
+++ b/web/tests/unit.test.js
@@ -1,0 +1,288 @@
+// Unit tests for pure JavaScript functions
+const assert = require('assert');
+const { escapeHtml, sortWorktrees, createState, saveState, loadState } = require('../lib.js');
+
+// Simple test runner
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    passed++;
+    console.log(`  ✓ ${name}`);
+  } catch (err) {
+    failed++;
+    console.log(`  ✗ ${name}`);
+    console.log(`    ${err.message}`);
+  }
+}
+
+function describe(name, fn) {
+  console.log(`\n${name}`);
+  fn();
+}
+
+// Mock localStorage
+function createMockStorage() {
+  const store = {};
+  return {
+    getItem: (key) => store[key] || null,
+    setItem: (key, value) => { store[key] = value; },
+    clear: () => { for (const k in store) delete store[k]; },
+  };
+}
+
+// Tests
+describe('escapeHtml', () => {
+  test('escapes ampersand', () => {
+    assert.strictEqual(escapeHtml('foo & bar'), 'foo &amp; bar');
+  });
+
+  test('escapes less than', () => {
+    assert.strictEqual(escapeHtml('<script>'), '&lt;script&gt;');
+  });
+
+  test('escapes greater than', () => {
+    assert.strictEqual(escapeHtml('a > b'), 'a &gt; b');
+  });
+
+  test('escapes double quotes', () => {
+    assert.strictEqual(escapeHtml('"quoted"'), '&quot;quoted&quot;');
+  });
+
+  test('escapes single quotes', () => {
+    assert.strictEqual(escapeHtml("it's"), "it&#39;s");
+  });
+
+  test('handles null/undefined', () => {
+    assert.strictEqual(escapeHtml(null), '');
+    assert.strictEqual(escapeHtml(undefined), '');
+    assert.strictEqual(escapeHtml(''), '');
+  });
+
+  test('prevents XSS injection', () => {
+    const malicious = '<script>alert("xss")</script>';
+    const escaped = escapeHtml(malicious);
+    assert.ok(!escaped.includes('<script>'));
+    assert.ok(escaped.includes('&lt;script&gt;'));
+  });
+
+  test('handles complex mixed content', () => {
+    const input = '<div class="foo">Tom & Jerry\'s "Show"</div>';
+    const expected = '&lt;div class=&quot;foo&quot;&gt;Tom &amp; Jerry&#39;s &quot;Show&quot;&lt;/div&gt;';
+    assert.strictEqual(escapeHtml(input), expected);
+  });
+});
+
+describe('sortWorktrees - default sort', () => {
+  const worktrees = [
+    { folder: 'feature-z', branch: 'z', dirty: false, unpushed: 0, prState: null },
+    { folder: 'feature-a', branch: 'a', dirty: true, unpushed: 0, prState: null },
+    { folder: 'feature-m', branch: 'm', dirty: false, unpushed: 0, prState: 'OPEN' },
+    { folder: 'feature-b', branch: 'b', dirty: false, unpushed: 0, prState: 'CLOSED' },
+  ];
+
+  test('OPEN PRs come first', () => {
+    const sorted = sortWorktrees(worktrees, 'default', 'asc');
+    assert.strictEqual(sorted[0].prState, 'OPEN');
+  });
+
+  test('dirty worktrees come before clean (no PR)', () => {
+    const sorted = sortWorktrees(worktrees, 'default', 'asc');
+    // After OPEN and CLOSED PRs, dirty should come before clean
+    const noPrWorktrees = sorted.filter(w => !w.prState);
+    const dirtyIdx = noPrWorktrees.findIndex(w => w.dirty);
+    const cleanIdx = noPrWorktrees.findIndex(w => !w.dirty);
+    assert.ok(dirtyIdx < cleanIdx, 'Dirty worktrees should sort before clean');
+  });
+
+  test('respects PR state ordering: OPEN < DRAFT < MERGED < CLOSED', () => {
+    const prWorktrees = [
+      { folder: 'd', branch: 'd', dirty: false, unpushed: 0, prState: 'CLOSED' },
+      { folder: 'a', branch: 'a', dirty: false, unpushed: 0, prState: 'OPEN' },
+      { folder: 'c', branch: 'c', dirty: false, unpushed: 0, prState: 'MERGED' },
+      { folder: 'b', branch: 'b', dirty: false, unpushed: 0, prState: 'DRAFT' },
+    ];
+    const sorted = sortWorktrees(prWorktrees, 'default', 'asc');
+    assert.deepStrictEqual(
+      sorted.map(w => w.prState),
+      ['OPEN', 'DRAFT', 'MERGED', 'CLOSED']
+    );
+  });
+});
+
+describe('sortWorktrees - folder sort', () => {
+  const worktrees = [
+    { folder: 'zebra', branch: 'x', dirty: false, unpushed: 0 },
+    { folder: 'alpha', branch: 'y', dirty: false, unpushed: 0 },
+    { folder: 'middle', branch: 'z', dirty: false, unpushed: 0 },
+  ];
+
+  test('sorts alphabetically ascending', () => {
+    const sorted = sortWorktrees(worktrees, 'folder', 'asc');
+    assert.deepStrictEqual(sorted.map(w => w.folder), ['alpha', 'middle', 'zebra']);
+  });
+
+  test('sorts alphabetically descending', () => {
+    const sorted = sortWorktrees(worktrees, 'folder', 'desc');
+    assert.deepStrictEqual(sorted.map(w => w.folder), ['zebra', 'middle', 'alpha']);
+  });
+});
+
+describe('sortWorktrees - branch sort', () => {
+  const worktrees = [
+    { folder: 'a', branch: 'feature/z', dirty: false, unpushed: 0 },
+    { folder: 'b', branch: 'feature/a', dirty: false, unpushed: 0 },
+    { folder: 'c', branch: 'main', dirty: false, unpushed: 0 },
+  ];
+
+  test('sorts by branch ascending', () => {
+    const sorted = sortWorktrees(worktrees, 'branch', 'asc');
+    assert.deepStrictEqual(sorted.map(w => w.branch), ['feature/a', 'feature/z', 'main']);
+  });
+});
+
+describe('sortWorktrees - status sort', () => {
+  const worktrees = [
+    { folder: 'clean', branch: 'a', dirty: false, unpushed: 0 },
+    { folder: 'unpushed', branch: 'b', dirty: false, unpushed: 2 },
+    { folder: 'dirty', branch: 'c', dirty: true, unpushed: 0 },
+  ];
+
+  test('dirty first, then unpushed, then clean', () => {
+    const sorted = sortWorktrees(worktrees, 'status', 'asc');
+    assert.deepStrictEqual(sorted.map(w => w.folder), ['dirty', 'unpushed', 'clean']);
+  });
+
+  test('reverse order when descending', () => {
+    const sorted = sortWorktrees(worktrees, 'status', 'desc');
+    assert.deepStrictEqual(sorted.map(w => w.folder), ['clean', 'unpushed', 'dirty']);
+  });
+});
+
+describe('sortWorktrees - pr sort', () => {
+  const worktrees = [
+    { folder: 'a', branch: 'a', dirty: false, unpushed: 0, prState: null },
+    { folder: 'b', branch: 'b', dirty: false, unpushed: 0, prState: 'MERGED' },
+    { folder: 'c', branch: 'c', dirty: false, unpushed: 0, prState: 'OPEN' },
+  ];
+
+  test('OPEN first, then other states, then null', () => {
+    const sorted = sortWorktrees(worktrees, 'pr', 'asc');
+    assert.strictEqual(sorted[0].prState, 'OPEN');
+    assert.strictEqual(sorted[1].prState, 'MERGED');
+    assert.strictEqual(sorted[2].prState, null);
+  });
+});
+
+describe('sortWorktrees - immutability', () => {
+  test('does not mutate original array', () => {
+    const original = [
+      { folder: 'z', branch: 'z', dirty: false, unpushed: 0 },
+      { folder: 'a', branch: 'a', dirty: false, unpushed: 0 },
+    ];
+    const originalOrder = original.map(w => w.folder);
+    sortWorktrees(original, 'folder', 'asc');
+    assert.deepStrictEqual(original.map(w => w.folder), originalOrder);
+  });
+});
+
+describe('state persistence - saveState', () => {
+  test('saves state to storage', () => {
+    const storage = createMockStorage();
+    const state = {
+      selectedProject: 'my-project',
+      worktreeIndex: 5,
+      sortColumn: 'folder',
+      sortDirection: 'desc',
+      currentView: 'prs',
+    };
+    saveState(state, storage);
+    const saved = JSON.parse(storage.getItem('bearing-state'));
+    assert.strictEqual(saved.selectedProject, 'my-project');
+    assert.strictEqual(saved.worktreeIndex, 5);
+    assert.strictEqual(saved.sortColumn, 'folder');
+    assert.strictEqual(saved.sortDirection, 'desc');
+    assert.strictEqual(saved.currentView, 'prs');
+  });
+});
+
+describe('state persistence - loadState', () => {
+  test('loads saved state', () => {
+    const storage = createMockStorage();
+    storage.setItem('bearing-state', JSON.stringify({
+      selectedProject: 'loaded-project',
+      worktreeIndex: 3,
+      sortColumn: 'branch',
+      sortDirection: 'asc',
+      currentView: 'issues',
+    }));
+    const state = createState();
+    loadState(state, storage);
+    assert.strictEqual(state.selectedProject, 'loaded-project');
+    assert.strictEqual(state.worktreeIndex, 3);
+    assert.strictEqual(state.sortColumn, 'branch');
+    assert.strictEqual(state.currentView, 'issues');
+  });
+
+  test('handles missing storage gracefully', () => {
+    const storage = createMockStorage();
+    const state = createState();
+    loadState(state, storage);
+    // Should use defaults
+    assert.strictEqual(state.selectedProject, null);
+    assert.strictEqual(state.sortColumn, 'default');
+  });
+
+  test('handles corrupted JSON gracefully', () => {
+    const storage = createMockStorage();
+    storage.setItem('bearing-state', 'not valid json {{{');
+    const state = createState();
+    // Should not throw
+    loadState(state, storage);
+    // Should retain defaults
+    assert.strictEqual(state.selectedProject, null);
+  });
+
+  test('handles partial data gracefully', () => {
+    const storage = createMockStorage();
+    storage.setItem('bearing-state', JSON.stringify({
+      selectedProject: 'partial-project',
+      // Missing other fields
+    }));
+    const state = createState();
+    loadState(state, storage);
+    assert.strictEqual(state.selectedProject, 'partial-project');
+    assert.strictEqual(state.worktreeIndex, 0); // Default
+    assert.strictEqual(state.sortColumn, 'default'); // Default
+  });
+});
+
+describe('state persistence - round trip', () => {
+  test('save then load preserves state', () => {
+    const storage = createMockStorage();
+    const originalState = {
+      selectedProject: 'roundtrip-test',
+      worktreeIndex: 7,
+      sortColumn: 'status',
+      sortDirection: 'desc',
+      currentView: 'worktrees',
+    };
+    saveState(originalState, storage);
+    const loadedState = createState();
+    loadState(loadedState, storage);
+    assert.strictEqual(loadedState.selectedProject, originalState.selectedProject);
+    assert.strictEqual(loadedState.worktreeIndex, originalState.worktreeIndex);
+    assert.strictEqual(loadedState.sortColumn, originalState.sortColumn);
+    assert.strictEqual(loadedState.sortDirection, originalState.sortDirection);
+    assert.strictEqual(loadedState.currentView, originalState.currentView);
+  });
+});
+
+// Summary
+console.log(`\n${'='.repeat(40)}`);
+console.log(`Tests: ${passed} passed, ${failed} failed`);
+console.log(`${'='.repeat(40)}\n`);
+
+process.exit(failed > 0 ? 1 : 0);

--- a/web/tests/visual/components.spec.js
+++ b/web/tests/visual/components.spec.js
@@ -1,0 +1,356 @@
+// @ts-check
+const { test, expect } = require('@playwright/test');
+
+/**
+ * Component-level visual regression tests.
+ * Screenshots individual panels rather than the full page for more stable tests.
+ */
+
+test.describe('Projects Panel', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+  });
+
+  test('empty state', async ({ page }) => {
+    // Mock empty projects
+    await page.route('**/api/projects', route => {
+      route.fulfill({ json: [] });
+    });
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+
+    const panel = page.locator('#projects-panel');
+    await expect(panel).toHaveScreenshot('projects-empty.png');
+  });
+
+  test('with items', async ({ page }) => {
+    // Mock projects with data
+    await page.route('**/api/projects', route => {
+      route.fulfill({
+        json: [
+          { name: 'bearing', count: 5 },
+          { name: 'sailkit', count: 3 },
+          { name: 'fightingwithai.com', count: 2 },
+        ],
+      });
+    });
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+
+    const panel = page.locator('#projects-panel');
+    await expect(panel).toHaveScreenshot('projects-with-items.png');
+  });
+
+  test('with selection', async ({ page }) => {
+    // Mock projects with data
+    await page.route('**/api/projects', route => {
+      route.fulfill({
+        json: [
+          { name: 'bearing', count: 5 },
+          { name: 'sailkit', count: 3 },
+          { name: 'fightingwithai.com', count: 2 },
+        ],
+      });
+    });
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+
+    // Navigate to second item
+    await page.keyboard.press('j');
+
+    const panel = page.locator('#projects-panel');
+    await expect(panel).toHaveScreenshot('projects-selected.png');
+  });
+});
+
+test.describe('Worktrees Table', () => {
+  const mockWorktrees = [
+    { repo: 'bearing', folder: 'bearing', branch: 'main', base: true, dirty: false, unpushed: 0, prState: null },
+    { repo: 'bearing', folder: 'bearing-feature-1', branch: 'feature-1', base: false, dirty: true, unpushed: 2, prState: 'OPEN' },
+    { repo: 'bearing', folder: 'bearing-bugfix', branch: 'bugfix', base: false, dirty: false, unpushed: 0, prState: 'MERGED' },
+  ];
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+  });
+
+  test('empty state', async ({ page }) => {
+    await page.route('**/api/projects', route => {
+      route.fulfill({ json: [{ name: 'empty-project', count: 0 }] });
+    });
+    await page.route('**/api/worktrees', route => {
+      route.fulfill({ json: [] });
+    });
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+
+    const panel = page.locator('#worktrees-panel');
+    await expect(panel).toHaveScreenshot('worktrees-empty.png');
+  });
+
+  test('with data', async ({ page }) => {
+    await page.route('**/api/projects', route => {
+      route.fulfill({ json: [{ name: 'bearing', count: 3 }] });
+    });
+    await page.route('**/api/worktrees', route => {
+      route.fulfill({ json: mockWorktrees });
+    });
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+
+    const panel = page.locator('#worktrees-panel');
+    await expect(panel).toHaveScreenshot('worktrees-with-data.png');
+  });
+
+  test('sorted by folder ascending', async ({ page }) => {
+    await page.route('**/api/projects', route => {
+      route.fulfill({ json: [{ name: 'bearing', count: 3 }] });
+    });
+    await page.route('**/api/worktrees', route => {
+      route.fulfill({ json: mockWorktrees });
+    });
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+
+    // Click folder column to sort
+    await page.click('[data-sort="folder"]');
+
+    const panel = page.locator('#worktrees-panel');
+    await expect(panel).toHaveScreenshot('worktrees-sorted-folder-asc.png');
+  });
+
+  test('sorted by folder descending', async ({ page }) => {
+    await page.route('**/api/projects', route => {
+      route.fulfill({ json: [{ name: 'bearing', count: 3 }] });
+    });
+    await page.route('**/api/worktrees', route => {
+      route.fulfill({ json: mockWorktrees });
+    });
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+
+    // Click folder column twice to sort descending
+    await page.click('[data-sort="folder"]');
+    await page.click('[data-sort="folder"]');
+
+    const panel = page.locator('#worktrees-panel');
+    await expect(panel).toHaveScreenshot('worktrees-sorted-folder-desc.png');
+  });
+
+  test('sorted by status', async ({ page }) => {
+    await page.route('**/api/projects', route => {
+      route.fulfill({ json: [{ name: 'bearing', count: 3 }] });
+    });
+    await page.route('**/api/worktrees', route => {
+      route.fulfill({ json: mockWorktrees });
+    });
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+
+    // Click status column to sort
+    await page.click('[data-sort="status"]');
+
+    const panel = page.locator('#worktrees-panel');
+    await expect(panel).toHaveScreenshot('worktrees-sorted-status.png');
+  });
+
+  test('sorted by PR state', async ({ page }) => {
+    await page.route('**/api/projects', route => {
+      route.fulfill({ json: [{ name: 'bearing', count: 3 }] });
+    });
+    await page.route('**/api/worktrees', route => {
+      route.fulfill({ json: mockWorktrees });
+    });
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+
+    // Click PR column to sort
+    await page.click('[data-sort="pr"]');
+
+    const panel = page.locator('#worktrees-panel');
+    await expect(panel).toHaveScreenshot('worktrees-sorted-pr.png');
+  });
+});
+
+test.describe('Details Panel', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+  });
+
+  test('empty state', async ({ page }) => {
+    await page.route('**/api/projects', route => {
+      route.fulfill({ json: [] });
+    });
+    await page.route('**/api/worktrees', route => {
+      route.fulfill({ json: [] });
+    });
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+
+    const panel = page.locator('#details-panel');
+    await expect(panel).toHaveScreenshot('details-empty.png');
+  });
+
+  test('with worktree selected', async ({ page }) => {
+    const mockWorktrees = [
+      {
+        repo: 'bearing',
+        folder: 'bearing-feature',
+        branch: 'feature-branch',
+        base: false,
+        dirty: true,
+        unpushed: 3,
+        prState: 'OPEN',
+        purpose: 'Adding new dashboard feature',
+        status: 'In progress',
+      },
+    ];
+
+    await page.route('**/api/projects', route => {
+      route.fulfill({ json: [{ name: 'bearing', count: 1 }] });
+    });
+    await page.route('**/api/worktrees', route => {
+      route.fulfill({ json: mockWorktrees });
+    });
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+
+    // Move to worktree table and select first item
+    await page.keyboard.press('l');
+    await page.keyboard.press('Enter');
+
+    const panel = page.locator('#details-panel');
+    await expect(panel).toHaveScreenshot('details-with-data.png');
+  });
+
+  test('with base worktree selected', async ({ page }) => {
+    const mockWorktrees = [
+      {
+        repo: 'bearing',
+        folder: 'bearing',
+        branch: 'main',
+        base: true,
+        dirty: false,
+        unpushed: 0,
+        prState: null,
+      },
+    ];
+
+    await page.route('**/api/projects', route => {
+      route.fulfill({ json: [{ name: 'bearing', count: 1 }] });
+    });
+    await page.route('**/api/worktrees', route => {
+      route.fulfill({ json: mockWorktrees });
+    });
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+
+    const panel = page.locator('#details-panel');
+    await expect(panel).toHaveScreenshot('details-base-worktree.png');
+  });
+});
+
+test.describe('Tab Bar', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+  });
+
+  test('worktrees tab active (default)', async ({ page }) => {
+    const tabBar = page.locator('.tab-bar');
+    await expect(tabBar).toHaveScreenshot('tabs-worktrees-active.png');
+  });
+
+  test('issues tab active', async ({ page }) => {
+    await page.keyboard.press('2');
+    await page.waitForTimeout(100);
+
+    const tabBar = page.locator('.tab-bar');
+    await expect(tabBar).toHaveScreenshot('tabs-issues-active.png');
+  });
+
+  test('prs tab active', async ({ page }) => {
+    await page.keyboard.press('3');
+    await page.waitForTimeout(100);
+
+    const tabBar = page.locator('.tab-bar');
+    await expect(tabBar).toHaveScreenshot('tabs-prs-active.png');
+  });
+});
+
+test.describe('Help Modal', () => {
+  test('modal appearance', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    // Open help modal
+    await page.keyboard.press('?');
+    await page.waitForTimeout(100);
+
+    const modal = page.locator('#help-modal');
+    await expect(modal).toHaveScreenshot('help-modal.png');
+  });
+});
+
+test.describe('Plans Modal', () => {
+  test('empty state', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    await page.route('**/api/plans', route => {
+      route.fulfill({ json: [] });
+    });
+
+    // Open plans modal
+    await page.keyboard.press('p');
+    await page.waitForTimeout(200);
+
+    const modal = page.locator('#plans-modal');
+    await expect(modal).toHaveScreenshot('plans-modal-empty.png');
+  });
+
+  test('with plans', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    await page.route('**/api/plans', route => {
+      route.fulfill({
+        json: [
+          { title: 'TUI Test Foundation', project: 'bearing', status: 'active', issue: 17 },
+          { title: 'Multi-view TUI', project: 'bearing', status: 'planned', issue: 13 },
+          { title: 'Daemon Plans Indexing', project: 'bearing', status: 'completed', issue: 14 },
+        ],
+      });
+    });
+
+    // Open plans modal
+    await page.keyboard.press('p');
+    await page.waitForTimeout(200);
+
+    const modal = page.locator('#plans-modal');
+    await expect(modal).toHaveScreenshot('plans-modal-with-data.png');
+  });
+});
+
+test.describe('Status Indicator', () => {
+  test('connected state', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    const indicator = page.locator('#status-indicator');
+    await expect(indicator).toHaveScreenshot('status-connected.png');
+  });
+});
+
+test.describe('Footer Bar', () => {
+  test('default appearance', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    const footer = page.locator('#footer-bar');
+    await expect(footer).toHaveScreenshot('footer-bar.png');
+  });
+});


### PR DESCRIPTION
## Summary
- Add tab bar to web dashboard with Worktrees/Issues/PRs tabs
- Keyboard navigation: 1=Worktrees, 2=Issues, 3=PRs, Tab=cycle views
- Add GET /api/issues endpoint returning plans with issue numbers
- Parse issue numbers from frontmatter (#123 or 123 format)

Part of the GitHub-like views plan for making Bearing navigation more familiar.

## Test plan
- [x] All daemon tests pass (13 tests including new TestHandleIssues)
- [x] Tab switching works via click and keyboard
- [x] Issues/PRs views show placeholder (content coming soon)

🤖 Generated with [Claude Code](https://claude.com/claude-code)