### PR TITLE
Web dashboard: 2-tab layout (Worktrees+PRs | Plans+Issues)

### DIFF
--- a/web/.gitignore
+++ b/web/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+package-lock.json
+playwright-report/
+test-results/

--- a/web/index.html
+++ b/web/index.html
@@ -8,9 +8,8 @@
 </head>
 <body>
   <nav class="tab-bar">
-    <button class="tab active" data-view="worktrees">Worktrees</button>
-    <button class="tab" data-view="issues">Issues</button>
-    <button class="tab" data-view="prs">PRs</button>
+    <button class="tab active" data-view="operational">Worktrees + PRs</button>
+    <button class="tab" data-view="planning">Plans + Issues</button>
   </nav>
 
   <main id="main-container">
@@ -19,8 +18,8 @@
       <ul id="project-list" class="list" tabindex="0"></ul>
     </aside>
 
-    <section id="worktrees-panel" class="panel">
-      <div class="panel-header">[1] Worktrees</div>
+    <section id="worktrees-panel" class="panel view-panel" data-view="operational">
+      <div class="panel-header">[1] Worktrees + PRs</div>
       <div id="worktree-table" class="table" tabindex="0">
         <div class="table-header">
           <span class="col-folder sortable" data-sort="folder">Folder</span>
@@ -29,6 +28,19 @@
           <span class="col-pr sortable" data-sort="pr">PR</span>
         </div>
         <div id="worktree-rows" class="table-body"></div>
+      </div>
+    </section>
+
+    <section id="plans-panel" class="panel view-panel hidden" data-view="planning">
+      <div class="panel-header">[1] Plans + Issues</div>
+      <div id="plans-table" class="table" tabindex="0">
+        <div class="table-header">
+          <span class="col-title sortable" data-sort="title">Title</span>
+          <span class="col-project sortable" data-sort="project">Project</span>
+          <span class="col-plan-status sortable" data-sort="status">Status</span>
+          <span class="col-issue sortable" data-sort="issue">Issue</span>
+        </div>
+        <div id="plans-rows" class="table-body"></div>
       </div>
     </section>
   </main>
@@ -41,12 +53,11 @@
   </section>
 
   <footer id="footer-bar">
-    <span><kbd>1</kbd>-<kbd>3</kbd> views</span>
+    <span><kbd>1</kbd>/<kbd>2</kbd> views</span>
     <span><kbd>Tab</kbd> cycle</span>
     <span><kbd>j/k</kbd> nav</span>
     <span><kbd>r</kbd>efresh</span>
-    <span><kbd>o</kbd>pen PR</span>
-    <span><kbd>p</kbd>lans</span>
+    <span><kbd>o</kbd>pen PR/issue</span>
     <span><kbd>/</kbd> search</span>
     <span><kbd>?</kbd> help</span>
     <span class="footer-spacer"></span>
@@ -59,9 +70,8 @@
       <h2>Bearing Dashboard - Keybindings</h2>
       <div class="keybindings">
         <h3>Navigation</h3>
-        <div class="binding"><kbd>1</kbd> Worktrees view</div>
-        <div class="binding"><kbd>2</kbd> Issues view</div>
-        <div class="binding"><kbd>3</kbd> PRs view</div>
+        <div class="binding"><kbd>1</kbd> Worktrees + PRs view</div>
+        <div class="binding"><kbd>2</kbd> Plans + Issues view</div>
         <div class="binding"><kbd>h</kbd> / <kbd>←</kbd> Focus left panel</div>
         <div class="binding"><kbd>l</kbd> / <kbd>→</kbd> Focus right panel</div>
         <div class="binding"><kbd>j</kbd> / <kbd>↓</kbd> Move down</div>
@@ -71,20 +81,11 @@
 
         <h3>Actions</h3>
         <div class="binding"><kbd>r</kbd> Refresh data</div>
-        <div class="binding"><kbd>o</kbd> Open PR in browser</div>
-        <div class="binding"><kbd>p</kbd> View plans</div>
+        <div class="binding"><kbd>o</kbd> Open PR/Issue in browser</div>
         <div class="binding"><kbd>/</kbd> or <kbd>Ctrl+K</kbd> Command palette</div>
         <div class="binding"><kbd>?</kbd> Show this help</div>
         <div class="binding"><kbd>Esc</kbd> Close modal</div>
       </div>
-    </div>
-  </div>
-
-  <!-- Plans Modal -->
-  <div id="plans-modal" class="modal hidden">
-    <div class="modal-content modal-wide">
-      <h2>Plans <span class="modal-hint">(press o to open issue, Esc to close)</span></h2>
-      <div id="plans-list" class="list" tabindex="0"></div>
     </div>
   </div>
 

--- a/web/playwright.config.js
+++ b/web/playwright.config.js
@@ -9,7 +9,7 @@ module.exports = defineConfig({
   workers: process.env.CI ? 1 : undefined,
   reporter: 'html',
   use: {
-    baseURL: 'http://localhost:8080',
+    baseURL: 'http://localhost:8374',
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
   },
@@ -20,9 +20,9 @@ module.exports = defineConfig({
     },
   ],
   webServer: {
-    command: 'cd .. && go run ./cmd/bearing daemon start --foreground --port 8080',
-    url: 'http://localhost:8080',
-    reuseExistingServer: !process.env.CI,
+    command: 'cd .. && go run ./cmd/bearing daemon start --foreground',
+    url: 'http://localhost:8374',
+    reuseExistingServer: true,
     timeout: 30000,
   },
 });

--- a/web/style.css
+++ b/web/style.css
@@ -151,6 +151,16 @@ body {
   flex: 1;
 }
 
+/* Plans Panel */
+#plans-panel {
+  flex: 1;
+}
+
+/* View panel visibility */
+.view-panel.hidden {
+  display: none;
+}
+
 /* Lists */
 .list {
   list-style: none;
@@ -270,11 +280,23 @@ body {
   font-weight: bold;
 }
 
-/* Table columns */
+/* Table columns - Worktrees */
 .col-folder { flex: 2; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .col-branch { flex: 1.5; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .col-status { flex: 1; text-align: center; }
 .col-pr { flex: 0.8; text-align: center; }
+
+/* Table columns - Plans */
+.col-title { flex: 2; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.col-project { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--text-dim); }
+.col-plan-status { flex: 0.8; text-align: center; }
+.col-issue { flex: 0.6; text-align: center; color: var(--accent-cyan); }
+
+/* Plan status badges */
+.plan-status-draft { color: var(--text-dim); }
+.plan-status-active { color: var(--accent-green); }
+.plan-status-done { color: var(--accent-blue); }
+.plan-status-archived { color: var(--text-dim); opacity: 0.5; }
 
 /* Status indicators */
 .status-dirty { color: var(--accent-yellow); }


### PR DESCRIPTION
## Summary
- Change from 3 tabs to 2 combined views: Worktrees+PRs (key 1) and Plans+Issues (key 2)
- Add plans table panel with sortable Title/Project/Status/Issue columns
- Fix plans API integration (uses `path` instead of `id`)
- Update keyboard handlers and tests for new view structure

Implements Phase 2 of plan v3u2w-web-dashboard.md

## Test plan
- [x] All 45 e2e tests pass
- [ ] Manual test: hard refresh browser at localhost:8374
- [ ] Verify keyboard navigation (1/2, Tab, j/k, o)
- [ ] Verify plans table shows correct data for selected project

🤖 Generated with [Claude Code](https://claude.ai/code)